### PR TITLE
add archive collector and enumerate ext

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,11 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          # Pin a concrete version: foundryup only queries the (anonymous,
+          # rate-limited) GitHub API to resolve the "stable"/"nightly"
+          # channels. A pinned tag is downloaded directly from release
+          # assets, avoiding the HTTP 403 rate-limit failures seen in CI.
+          version: v1.7.1
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,9 +942,13 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "anyhow",
+ "async-stream",
  "async-trait",
  "futures",
  "jsonrpsee",
+ "serde",
+ "serde_json",
+ "sqlx",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -993,6 +997,15 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1093,6 +1106,9 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -1200,7 +1216,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -1211,6 +1227,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1301,6 +1326,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -1398,6 +1432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1482,6 +1517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1595,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1664,17 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -1685,6 +1759,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1897,6 +1982,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.3",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,12 +2021,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2468,6 +2580,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -2480,6 +2595,29 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.8.1",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2527,6 +2665,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2589,6 +2737,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,6 +2764,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2744,6 +2919,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2761,7 +2942,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.12",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2771,6 +2952,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2832,6 +3022,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,6 +3047,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "potential_utf"
@@ -3056,6 +3263,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3133,6 +3349,26 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3651,6 +3887,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,6 +3903,194 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.3",
+ "hashlink",
+ "indexmap 2.9.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.101",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.12",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.12",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3671,6 +4104,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -3877,6 +4321,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4128,10 +4587,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -4228,6 +4708,12 @@ checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -4361,6 +4847,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4383,7 +4879,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-result",
  "windows-strings 0.4.2",
 ]
@@ -4417,6 +4913,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-registry"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4433,7 +4935,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -4442,7 +4944,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -4451,7 +4953,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -4461,6 +4963,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4482,6 +4993,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4494,6 +5014,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4536,6 +5071,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4554,6 +5095,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4569,6 +5116,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4602,6 +5155,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4617,6 +5176,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4638,6 +5203,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4653,6 +5224,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ tracing = "0.1.41"
 [[example]]
 name = "basic_example"
 path = "examples/basic_example.rs"
+
+[[example]]
+name = "persistence_example"
+path = "examples/persistence_example.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ alloy = { version = "1.0", features = [
     "full",
     "node-bindings",
 ] }
+## persistence
+sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+async-stream = "0.3"
 ## misc
 anyhow = "1.0.97"
 tracing = "0.1.41"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The **Engine** fans-out every event to every strategy via a `tokio::sync::broadc
 | | `EventCollector` | Subscribes to an arbitrary `alloy` subscription |
 | **Strategy** | `Strategy<E, A>` | User-defined: receives events, produces action streams |
 | **Executor** | `MempoolExecutor` | Submits transactions to the public mempool |
+| **Persistence** | `Persisted<C, S>` | Wraps a block-aware collector to record events to a SQL `Store` and replay them on restart |
 
 ## Combinators
 
@@ -51,6 +52,50 @@ let collector = block_collector.merge(mempool_collector);
 |---|---|
 | `ExecutorFilterMap` | Filter-maps actions before forwarding to an inner executor |
 | `.instrument(metrics)` | Wraps an executor (or strategy) with a `Metrics` callback |
+
+## Persistence
+
+A long-running strategy that restarts shouldn't have to re-sync from genesis.
+The `persistence` module records every event a collector sees into a SQL
+[`Store`](src/persistence/store.rs) (SQLite first), and on restart replays the
+stored history before catching up to — and following — the chain tip.
+
+Wrapping is a single call on any block-aware collector (one that implements
+`PersistableCollector`, e.g. `EventCollector`):
+
+```rust
+use artemis_light::{collectors::EventCollector, persistence::{PersistExt, SqliteStore}};
+use std::sync::Arc;
+
+// `sqlite::memory:` for ephemeral, or `sqlite:events.db` to survive restarts.
+let store = Arc::new(SqliteStore::connect("sqlite:events.db").await?);
+
+let collector = EventCollector::new(contract.MyEvent_filter());
+let persisted = collector.with_persistence(store);
+
+engine.add_collector(Box::new(persisted));
+```
+
+On `subscribe`, a `Persisted` collector chains three segments into one stream:
+
+1. **Replay** — stored events, reconstructed from the database (first subscribe
+   only; a reconnect does not re-replay the archive).
+2. **Backfill** — the RPC gap between the last stored block and the chain tip.
+3. **Live** — the tip onward, recording each completed block as it goes.
+
+Events must be `serde::Serialize + Deserialize`. The table name and columns are
+derived from the event's Solidity signature and field names; register a
+`TableSchema` override on the store to rename or retype columns. A full lossless
+JSON payload is stored alongside the derived columns so replay reconstructs the
+exact event. Writes are one transaction per complete block, and the stored block
+height only advances over a gap-free prefix.
+
+See [`examples/persistence_example.rs`](examples/persistence_example.rs) for a
+runnable demo (record live events, then recover them on a simulated restart):
+
+```sh
+cargo run --example persistence_example
+```
 
 ## Quickstart
 

--- a/examples/persistence_example.rs
+++ b/examples/persistence_example.rs
@@ -1,0 +1,105 @@
+//! Recording events to SQLite and replaying them on the next subscribe.
+//!
+//! Wrapping any block-aware collector with `.with_persistence(store)` makes it
+//! record every event it sees, and on the *first* subscribe replay the stored
+//! history before catching up to (and following) the chain tip. This is how a
+//! strategy survives a restart without re-syncing from genesis.
+//!
+//! Requires `anvil` on `$PATH` (ships with Foundry). Run with:
+//! ```sh
+//! cargo run --example persistence_example
+//! ```
+
+use std::sync::Arc;
+
+use alloy::node_bindings::Anvil;
+use alloy::primitives::U256;
+use alloy::providers::{ProviderBuilder, WsConnect};
+use alloy::signers::local::PrivateKeySigner;
+use alloy::sol;
+use anyhow::Result;
+use artemis_light::collectors::EventCollector;
+use artemis_light::persistence::{PersistExt, SqliteStore, Store};
+use artemis_light::types::Collector;
+use futures::StreamExt;
+
+sol! {
+    #[sol(rpc, bytecode = "6080604052348015600e575f5ffd5b5060d980601a5f395ff3fe6080604052348015600e575f5ffd5b50600436106030575f3560e01c80633fa4f2451460345780635524107714604d575b5f5ffd5b603b5f5481565b60405190815260200160405180910390f35b605c6058366004608d565b605e565b005b5f81815560405182917f012c78e2b84325878b1bd9d250d772cfe5bda7722d795f45036fa5e1e6e303fc91a250565b5f60208284031215609c575f5ffd5b503591905056fea264697066735822122050fddb04e40945ebc7c51aef06d27a86c4aa98943b773d9ffdc789caf784441064736f6c634300081e0033")]
+    contract Emitter {
+        uint256 public value;
+
+        // `Persisted` derives the table/columns from the event, so it must be
+        // `Serialize` (to write) and `Deserialize` (to replay).
+        #[derive(serde::Serialize, serde::Deserialize, Debug)]
+        event ValueSet(uint256 indexed value);
+
+        function setValue(uint256 _value) external {
+            value = _value;
+            emit ValueSet(_value);
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // A local chain mining one block per second, plus a deployed emitter.
+    let anvil = Anvil::new().block_time(1).try_spawn()?;
+    let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
+    let ws = WsConnect::new(anvil.ws_endpoint());
+    let provider = Arc::new(ProviderBuilder::new().wallet(signer).connect_ws(ws).await?);
+    let contract = Emitter::deploy(provider.clone()).await?;
+
+    // An in-memory store; use `SqliteStore::connect("sqlite:events.db")` to
+    // persist across process restarts.
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await?);
+
+    // ---- First run: record events as they arrive on the live chain. ----
+    //
+    // Wrap the event collector with persistence — the whole feature is this
+    // one `.with_persistence(...)` call.
+    let persisted = EventCollector::new(contract.ValueSet_filter()).with_persistence(store.clone());
+
+    println!("First run — emitting 3 events on the live chain:");
+    let mut stream = persisted.subscribe().await?;
+    for v in [10u64, 20, 30] {
+        contract
+            .setValue(U256::from(v))
+            .send()
+            .await?
+            .watch()
+            .await?;
+        let event = stream.next().await.expect("event");
+        println!("  [live] ValueSet({})", event.value);
+    }
+    // Drop the subscription and the wrapper, as a process shutdown would.
+    drop(stream);
+    drop(persisted);
+
+    // Each event landed in its own block. A block is flushed once a higher one
+    // is seen, so 10 and 20 are persisted while 30's block is still "open".
+    println!(
+        "\nHighest persisted block: {:?}",
+        store.last_block("value_set").await?
+    );
+
+    // ---- "Restart": a fresh wrapper over the same store. ----
+    //
+    // Replay runs on a wrapper's *first* subscribe (a reconnect of the same
+    // wrapper does not re-replay), so recovering history after a restart means
+    // a new `Persisted` over the same database — exactly what a relaunched
+    // process does.
+    println!("\nRestart — a new collector over the same SQLite store recovers history:");
+    let recovered = EventCollector::new(contract.ValueSet_filter()).with_persistence(store.clone());
+    let mut stream = recovered.subscribe().await?;
+
+    // 10 and 20 are replayed straight from the database; 30's still-open block
+    // is re-fetched by the backfill query — all three return with no new chain
+    // activity needed.
+    for _ in 0..3 {
+        let event = stream.next().await.expect("recovered event");
+        println!("  [recovered] ValueSet({})", event.value);
+    }
+
+    println!("\nDone!");
+    Ok(())
+}

--- a/src/collectors/event_collector.rs
+++ b/src/collectors/event_collector.rs
@@ -1,3 +1,4 @@
+use crate::persistence::PersistableCollector;
 use crate::types::{Collector, CollectorStream};
 use alloy::{contract::Event, providers::Provider, sol_types::SolEvent};
 use anyhow::Result;
@@ -33,5 +34,52 @@ where
             }
         });
         Ok(Box::pin(stream))
+    }
+}
+
+/// The [`EventCollector`] is block-aware: it recovers each event's block number
+/// from its [`Log`](alloy::rpc::types::Log) and can replay a historical range
+/// via the provider, so it can be wrapped with persistence.
+#[async_trait]
+impl<P, E> PersistableCollector<E> for EventCollector<P, E>
+where
+    P: Provider + Clone + Send + Sync,
+    E: SolEvent + Send + Sync,
+{
+    async fn subscribe_indexed(&self) -> Result<CollectorStream<'_, (u64, E)>> {
+        let stream = self.event.subscribe().await?.into_stream();
+        let stream = stream.filter_map(|el| match el {
+            Ok((event, log)) => match log.block_number {
+                Some(block) => Some((block, event)),
+                None => {
+                    tracing::warn!("Event log missing block number; skipping");
+                    None
+                }
+            },
+            Err(e) => {
+                tracing::warn!("Failed to decode event log: {}", e);
+                None
+            }
+        });
+        Ok(Box::pin(stream))
+    }
+
+    async fn query_range(&self, from: u64, to: u64) -> Result<CollectorStream<'_, (u64, E)>> {
+        // Reuse the collector's filter (address + signature), narrowed to the
+        // requested block range, against a clone of the provider.
+        let ranged = Event::new(self.event.provider.clone(), self.event.filter.clone())
+            .from_block(from)
+            .to_block(to);
+        let events: Vec<(u64, E)> = ranged
+            .query()
+            .await?
+            .into_iter()
+            .filter_map(|(event, log)| log.block_number.map(|block| (block, event)))
+            .collect();
+        Ok(Box::pin(tokio_stream::iter(events)))
+    }
+
+    async fn tip(&self) -> Result<u64> {
+        Ok(self.event.provider.get_block_number().await?)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,11 @@ pub mod executors;
 /// This module contains the core type definitions for Artemis.
 pub mod types;
 
+/// This module contains persistence: a SQL [`Store`](persistence::Store) and a
+/// [`Persisted`](persistence::Persisted) collector wrapper that records events
+/// and replays them on subscribe.
+pub mod persistence;
+
 /// This module contains syntax extensions for the `Collector` trait.
 pub mod collector_ext;
 // pub use collector_ext::*;

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -1,0 +1,20 @@
+//! Persistence for the event pipeline.
+//!
+//! A [`Store`](crate::persistence::Store) is a SQL backend (SQLite first) that
+//! records indexed events one table per event type, plus the last processed
+//! block. The [`Persisted`](crate::persistence::Persisted) wrapper turns any
+//! block-aware collector into one that records every event it sees and, on
+//! subscribe, replays the stored history before catching up to and following
+//! the chain tip.
+
+mod persisted;
+mod record;
+mod schema;
+mod sqlite;
+mod store;
+
+pub use persisted::*;
+pub use record::*;
+pub use schema::*;
+pub use sqlite::*;
+pub use store::*;

--- a/src/persistence/persisted.rs
+++ b/src/persistence/persisted.rs
@@ -89,12 +89,11 @@ where
         //    re-emitting the whole archive would re-deliver every historical
         //    event to strategies, so subsequent subscribes skip replay and let
         //    the backfill segment cover only the gap since the last stored block.
-        let replayed: CollectorStream<'_, E> = if self.replayed.load(Ordering::SeqCst) {
-            Box::pin(futures::stream::empty()) as CollectorStream<'_, E>
+        let first_subscribe = !self.replayed.load(Ordering::SeqCst);
+        let replayed: CollectorStream<'_, E> = if first_subscribe {
+            replay_stored::<E, S>(&self.store, table, last).await?
         } else {
-            let stream = replay_stored::<E, S>(&self.store, table, last).await?;
-            self.replayed.store(true, Ordering::SeqCst);
-            stream
+            Box::pin(futures::stream::empty()) as CollectorStream<'_, E>
         };
 
         // 2. Backfill the RPC gap `[last+1 ..= tip]`. These are complete blocks,
@@ -102,6 +101,15 @@ where
         let backfill_from = last.map(|l| l + 1).unwrap_or(0);
         let backfill_source = self.collector.query_range(backfill_from, tip).await?;
         let backfill = persist_and_emit(backfill_source, &self.store, true);
+
+        // Only now — after every fallible setup step has succeeded — mark the
+        // replay segment as consumed. The engine retries `subscribe` when it
+        // returns an error, so flipping this flag earlier (e.g. right after
+        // `replay_stored`) would make a retry skip the DB replay while backfill
+        // covers only blocks after `last`, stranding the stored history.
+        if first_subscribe {
+            self.replayed.store(true, Ordering::SeqCst);
+        }
 
         // 3. Live tail, strictly above the backfill cut so the two segments are
         //    disjoint. A live subscription streams from "now", whose lower edge

--- a/src/persistence/persisted.rs
+++ b/src/persistence/persisted.rs
@@ -1,0 +1,214 @@
+//! [`Persisted`]: a [`Collector`] wrapper that records every event it sees and,
+//! on subscribe, replays stored history before following the chain tip.
+
+use std::any::TypeId;
+
+use alloy::sol_types::SolEvent;
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use super::record::{PAYLOAD_COLUMN, derive_record_with, from_payload, table_name};
+use super::schema::{Row, SqlType, SqlValue, TableSchema};
+use super::store::Store;
+use crate::types::{Collector, CollectorStream};
+
+/// A collector that is aware of block numbers and can replay historical block
+/// ranges — the capability [`Persisted`] needs to record events and fill the
+/// gap between the last stored block and the chain tip.
+///
+/// Implemented by collectors that wrap a queryable source (e.g. an
+/// `EventCollector` over alloy's `Event`).
+#[async_trait]
+pub trait PersistableCollector<E>: Send + Sync {
+    /// Live, block-numbered events from the chain tip onward.
+    async fn subscribe_indexed(&self) -> Result<CollectorStream<'_, (u64, E)>>;
+
+    /// Historical block-numbered events for the inclusive range `from..=to`.
+    async fn query_range(&self, from: u64, to: u64) -> Result<CollectorStream<'_, (u64, E)>>;
+
+    /// The current chain tip (latest block number).
+    async fn tip(&self) -> Result<u64>;
+}
+
+/// Extension method that wraps a [`PersistableCollector`] with a [`Store`].
+pub trait PersistExt<E>: PersistableCollector<E> + Sized {
+    /// Record every event into `store`, replaying stored history on subscribe.
+    fn with_persistence<S: Store>(self, store: S) -> Persisted<Self, S> {
+        Persisted::new(self, store)
+    }
+}
+
+impl<E, C: PersistableCollector<E> + Sized> PersistExt<E> for C {}
+
+/// A [`PersistableCollector`] paired with a [`Store`].
+pub struct Persisted<C, S> {
+    collector: C,
+    store: S,
+}
+
+impl<C, S> Persisted<C, S> {
+    /// Pair `collector` with `store`. Prefer [`PersistExt::with_persistence`].
+    pub fn new(collector: C, store: S) -> Self {
+        Self { collector, store }
+    }
+}
+
+#[async_trait]
+impl<C, S, E> Collector<E> for Persisted<C, S>
+where
+    C: PersistableCollector<E>,
+    S: Store,
+    E: Serialize + DeserializeOwned + SolEvent + Send + Sync + 'static,
+{
+    async fn subscribe(&self) -> Result<CollectorStream<'_, E>> {
+        // Subscribe to the live tip first so events between the tip query and
+        // the live subscription are buffered by the source rather than lost.
+        let live_source = self.collector.subscribe_indexed().await?;
+        let tip = self.collector.tip().await?;
+
+        // The table name follows any registered override.
+        let table = resolved_table::<E, S>(&self.store);
+        let last = self.store.last_block(&table).await?;
+
+        // 1. Replay stored history, reconstructed from the database.
+        let replayed = replay_stored::<E, S>(&self.store, table, last).await?;
+
+        // 2. Backfill the RPC gap `[last+1 ..= tip]`. These are complete blocks,
+        //    so the trailing block is flushed too (`flush_final = true`).
+        let backfill_from = last.map(|l| l + 1).unwrap_or(0);
+        let backfill_source = self.collector.query_range(backfill_from, tip).await?;
+        let backfill = persist_and_emit(backfill_source, &self.store, true);
+
+        // 3. Live tail, strictly above the backfill cut so the two segments are
+        //    disjoint. A live subscription streams from "now", whose lower edge
+        //    is fuzzy around the head (it may re-deliver blocks `<= tip`), so we
+        //    enforce the `> tip` boundary rather than assume it. Live events end
+        //    an "open" block only when a higher block arrives, so the final
+        //    in-progress block is left unflushed (`flush_final = false`) and
+        //    re-fetched on restart.
+        let live_source = Box::pin(live_source.filter(move |(block, _)| {
+            let above_cut = *block > tip;
+            async move { above_cut }
+        })) as CollectorStream<'_, (u64, E)>;
+        let live = persist_and_emit(live_source, &self.store, false);
+
+        Ok(Box::pin(replayed.chain(backfill).chain(live)))
+    }
+}
+
+/// The resolved table name for event type `E`: an override's table if one is
+/// registered on `store`, otherwise the best-guess name from the signature.
+fn resolved_table<E, S>(store: &S) -> String
+where
+    E: SolEvent + 'static,
+    S: Store,
+{
+    store
+        .schema_override(TypeId::of::<E>())
+        .map(|schema| schema.table)
+        .unwrap_or_else(table_name::<E>)
+}
+
+/// Replay stored events up to and including `last`, reconstructed from each
+/// row's payload column. Returns an empty stream when nothing is stored.
+async fn replay_stored<'a, E, S>(
+    store: &'a S,
+    table: String,
+    last: Option<u64>,
+) -> Result<CollectorStream<'a, E>>
+where
+    E: DeserializeOwned + SolEvent + Send + 'a,
+    S: Store + 'a,
+{
+    let Some(to) = last else {
+        return Ok(Box::pin(futures::stream::empty()));
+    };
+
+    let payload_schema = TableSchema::new(table).col(PAYLOAD_COLUMN, SqlType::Text);
+    let rows = store.replay(&payload_schema, to).await?;
+    let mut events = Vec::with_capacity(rows.len());
+    for Row(cols) in rows {
+        match cols.into_iter().next() {
+            Some(SqlValue::Text(payload)) => match from_payload::<E>(&payload) {
+                Ok(event) => events.push(event),
+                Err(e) => tracing::error!("failed to reconstruct stored event: {e}"),
+            },
+            other => tracing::error!("unexpected payload column on replay: {other:?}"),
+        }
+    }
+    Ok(Box::pin(futures::stream::iter(events)))
+}
+
+/// Wrap a stream of `(block, event)` so that each event is buffered and written
+/// to `store` one transaction per complete block, while the plain events flow
+/// downstream unchanged.
+///
+/// A block is "complete" once a higher block number is observed. The trailing
+/// block is flushed at stream end only when `flush_final` is set (true for a
+/// finite backfill range, false for a live tail).
+fn persist_and_emit<'a, E, S>(
+    mut source: CollectorStream<'a, (u64, E)>,
+    store: &'a S,
+    flush_final: bool,
+) -> CollectorStream<'a, E>
+where
+    E: Serialize + SolEvent + Send + 'static,
+    S: Store + 'a,
+{
+    let stream = async_stream::stream! {
+        let override_ = store.schema_override(TypeId::of::<E>());
+        let mut buffer: Vec<Row> = Vec::new();
+        let mut current: Option<u64> = None;
+        let mut schema: Option<TableSchema> = None;
+        // Once a write fails we stop persisting so `last_block` keeps pointing
+        // at a contiguous, gap-free prefix. The event stream itself keeps
+        // flowing; a restart re-fetches everything after the last good block.
+        let mut healthy = true;
+
+        while let Some((block, event)) = source.next().await {
+            match derive_record_with(&event, override_.as_ref()) {
+                Ok((row_schema, row)) => {
+                    // The block advanced: the previous block is complete.
+                    if healthy
+                        && let (Some(cur), Some(sch)) = (current, &schema)
+                        && block != cur
+                    {
+                        healthy = flush(store, sch, cur, std::mem::take(&mut buffer)).await;
+                    }
+                    current = Some(block);
+                    schema = Some(row_schema);
+                    buffer.push(row);
+                }
+                // A derive failure must not break the event stream the rest of
+                // the pipeline depends on; log and keep forwarding.
+                Err(e) => tracing::error!("failed to derive row for persistence: {e}"),
+            }
+            yield event;
+        }
+
+        if healthy
+            && flush_final
+            && let (Some(cur), Some(sch)) = (current, &schema)
+        {
+            flush(store, sch, cur, std::mem::take(&mut buffer)).await;
+        }
+    };
+
+    Box::pin(stream)
+}
+
+/// Persist one block's buffered rows. Returns `false` (and logs) on failure so
+/// the caller can stop advancing the stored block height rather than leave a
+/// gap; never tears down the event stream.
+async fn flush<S: Store>(store: &S, schema: &TableSchema, block: u64, rows: Vec<Row>) -> bool {
+    match store.write_block(schema, block, rows).await {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::error!("failed to persist block {block}; halting persistence: {e}");
+            false
+        }
+    }
+}

--- a/src/persistence/persisted.rs
+++ b/src/persistence/persisted.rs
@@ -2,6 +2,7 @@
 //! on subscribe, replays stored history before following the chain tip.
 
 use std::any::TypeId;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use alloy::sol_types::SolEvent;
 use anyhow::Result;
@@ -47,12 +48,22 @@ impl<E, C: PersistableCollector<E> + Sized> PersistExt<E> for C {}
 pub struct Persisted<C, S> {
     collector: C,
     store: S,
+    /// Whether stored history has already been replayed to a subscriber. The
+    /// engine re-subscribes after a stream ends, and replaying the full archive
+    /// on every reconnect would re-deliver the entire history to strategies —
+    /// so the replay segment runs only on the first subscribe; thereafter the
+    /// backfill segment alone covers the gap since the last stored block.
+    replayed: AtomicBool,
 }
 
 impl<C, S> Persisted<C, S> {
     /// Pair `collector` with `store`. Prefer [`PersistExt::with_persistence`].
     pub fn new(collector: C, store: S) -> Self {
-        Self { collector, store }
+        Self {
+            collector,
+            store,
+            replayed: AtomicBool::new(false),
+        }
     }
 }
 
@@ -73,8 +84,18 @@ where
         let table = resolved_table::<E, S>(&self.store);
         let last = self.store.last_block(&table).await?;
 
-        // 1. Replay stored history, reconstructed from the database.
-        let replayed = replay_stored::<E, S>(&self.store, table, last).await?;
+        // 1. Replay stored history, reconstructed from the database — but only
+        //    on the first subscribe. On a reconnect the engine subscribes again;
+        //    re-emitting the whole archive would re-deliver every historical
+        //    event to strategies, so subsequent subscribes skip replay and let
+        //    the backfill segment cover only the gap since the last stored block.
+        let replayed: CollectorStream<'_, E> = if self.replayed.load(Ordering::SeqCst) {
+            Box::pin(futures::stream::empty()) as CollectorStream<'_, E>
+        } else {
+            let stream = replay_stored::<E, S>(&self.store, table, last).await?;
+            self.replayed.store(true, Ordering::SeqCst);
+            stream
+        };
 
         // 2. Backfill the RPC gap `[last+1 ..= tip]`. These are complete blocks,
         //    so the trailing block is flushed too (`flush_final = true`).
@@ -89,6 +110,15 @@ where
         //    an "open" block only when a higher block arrives, so the final
         //    in-progress block is left unflushed (`flush_final = false`) and
         //    re-fetched on restart.
+        //
+        //    The disjoint split assumes the backfill query reliably covers block
+        //    `tip`. If an RPC node's `eth_getLogs` lags behind its reported tip,
+        //    a log at exactly `tip` could be missing from the backfill yet
+        //    dropped here by the `> tip` filter — present in neither segment. A
+        //    fully robust fix needs per-log identity (block + log index) to
+        //    overlap the segments and de-duplicate; `(u64, E)` does not carry
+        //    that today, so it is deferred rather than reversing the deliberate
+        //    no-duplicate guarantee. See PR #18 / the boundary de-dup test.
         let live_source = Box::pin(live_source.filter(move |(block, _)| {
             let above_cut = *block > tip;
             async move { above_cut }
@@ -129,14 +159,16 @@ where
 
     let payload_schema = TableSchema::new(table).col(PAYLOAD_COLUMN, SqlType::Text);
     let rows = store.replay(&payload_schema, to).await?;
+    // A stored row that cannot be reconstructed is a hard error, not a row to
+    // skip: replay feeds strategies the historical view they reason over, and
+    // `_artemis_progress` already counts these blocks as processed. Silently
+    // omitting them would hand strategies a quietly truncated history, so we
+    // fail the subscribe (the engine retries, surfacing the problem) instead.
     let mut events = Vec::with_capacity(rows.len());
     for Row(cols) in rows {
         match cols.into_iter().next() {
-            Some(SqlValue::Text(payload)) => match from_payload::<E>(&payload) {
-                Ok(event) => events.push(event),
-                Err(e) => tracing::error!("failed to reconstruct stored event: {e}"),
-            },
-            other => tracing::error!("unexpected payload column on replay: {other:?}"),
+            Some(SqlValue::Text(payload)) => events.push(from_payload::<E>(&payload)?),
+            other => anyhow::bail!("unexpected payload column on replay: {other:?}"),
         }
     }
     Ok(Box::pin(futures::stream::iter(events)))

--- a/src/persistence/record.rs
+++ b/src/persistence/record.rs
@@ -1,0 +1,185 @@
+//! Best-guess mapping between events and SQL rows.
+//!
+//! The table name comes from the event's Solidity signature; column names come
+//! from the event's `serde` field names and column types are inferred from the
+//! serialised JSON. This requires events to implement [`serde::Serialize`].
+
+use std::collections::BTreeMap;
+
+use alloy::sol_types::SolEvent;
+use anyhow::{Context, Result};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use super::schema::{Column, Row, SqlType, SqlValue, TableSchema};
+
+/// Name of the implicit column holding each event's full JSON, used to
+/// losslessly reconstruct the event when replaying from the database.
+pub const PAYLOAD_COLUMN: &str = "_payload";
+
+/// The best-guess table name for an event type, derived from its Solidity
+/// signature: `ValueSet(uint256)` -> `value_set`.
+pub fn table_name<E: SolEvent>() -> String {
+    let signature = E::SIGNATURE;
+    let name = signature.split('(').next().unwrap_or(signature);
+    to_snake_case(name)
+}
+
+/// Map an event's top-level fields to `name -> (best-guess type, value)`,
+/// sorted by field name (deterministic across runs).
+fn field_map<E: Serialize>(event: &E) -> Result<BTreeMap<String, (SqlType, SqlValue)>> {
+    let value = serde_json::to_value(event).context("event is not serialisable to JSON")?;
+    let object = match value {
+        Value::Object(map) => map,
+        other => anyhow::bail!("event must serialise to a JSON object, got {other}"),
+    };
+    Ok(object
+        .into_iter()
+        .map(|(key, field)| (key, (infer_type(&field), json_to_sql(&field))))
+        .collect())
+}
+
+/// The best-guess [`TableSchema`] and [`Row`] for a serialisable event:
+/// one column per top-level field, named and typed from the serialised JSON.
+pub fn derive<E>(event: &E) -> Result<(TableSchema, Row)>
+where
+    E: Serialize + SolEvent,
+{
+    let fields = field_map(event)?;
+    let mut columns = Vec::with_capacity(fields.len());
+    let mut values = Vec::with_capacity(fields.len());
+    for (name, (ty, value)) in fields {
+        columns.push(Column::new(name, ty));
+        values.push(value);
+    }
+
+    Ok((
+        TableSchema {
+            table: table_name::<E>(),
+            columns,
+        },
+        Row(values),
+    ))
+}
+
+/// The schema and row for `event`, augmented with a [`PAYLOAD_COLUMN`] holding
+/// the event's full JSON. The per-field columns make the table queryable; the
+/// payload column makes replay lossless.
+pub fn derive_record<E>(event: &E) -> Result<(TableSchema, Row)>
+where
+    E: Serialize + SolEvent,
+{
+    derive_record_with(event, None)
+}
+
+/// Like [`derive_record`], but honouring an optional schema `override_`.
+///
+/// When an override is given, its table name and columns are used: each
+/// override column's value is looked up by name from the event's fields (a
+/// missing field becomes `NULL`), so columns may be renamed-away, reordered, or
+/// retyped without disturbing value alignment. The [`PAYLOAD_COLUMN`] is always
+/// appended for lossless replay.
+pub fn derive_record_with<E>(
+    event: &E,
+    override_: Option<&TableSchema>,
+) -> Result<(TableSchema, Row)>
+where
+    E: Serialize + SolEvent,
+{
+    let fields = field_map(event)?;
+
+    let (table, columns, mut values) = match override_ {
+        Some(schema) => {
+            let values = schema
+                .columns
+                .iter()
+                .map(|col| {
+                    fields
+                        .get(&col.name)
+                        .map(|(_, value)| value.clone())
+                        .unwrap_or(SqlValue::Null)
+                })
+                .collect();
+            (schema.table.clone(), schema.columns.clone(), values)
+        }
+        None => {
+            let mut columns = Vec::with_capacity(fields.len());
+            let mut values = Vec::with_capacity(fields.len());
+            for (name, (ty, value)) in &fields {
+                columns.push(Column::new(name.clone(), *ty));
+                values.push(value.clone());
+            }
+            (table_name::<E>(), columns, values)
+        }
+    };
+
+    let mut schema = TableSchema { table, columns };
+    let payload = serde_json::to_string(event).context("event is not serialisable to JSON")?;
+    schema
+        .columns
+        .push(Column::new(PAYLOAD_COLUMN, SqlType::Text));
+    values.push(SqlValue::Text(payload));
+
+    Ok((schema, Row(values)))
+}
+
+/// The schema used to read back stored events for replay: the table name plus
+/// the single [`PAYLOAD_COLUMN`]. Needs no event instance, so replay can run
+/// before any live event is seen.
+pub fn payload_schema<E: SolEvent>() -> TableSchema {
+    TableSchema::new(table_name::<E>()).col(PAYLOAD_COLUMN, SqlType::Text)
+}
+
+/// Reconstruct an event from a stored [`PAYLOAD_COLUMN`] value.
+pub fn from_payload<E: DeserializeOwned>(payload: &str) -> Result<E> {
+    serde_json::from_str(payload).context("stored payload is not valid for this event type")
+}
+
+/// Best-guess SQL type for a serialised field value.
+fn infer_type(value: &Value) -> SqlType {
+    match value {
+        Value::Bool(_) => SqlType::Integer,
+        Value::Number(n) if n.is_i64() || n.is_u64() => SqlType::Integer,
+        Value::Number(_) => SqlType::Real,
+        Value::String(_) => SqlType::Text,
+        // Arrays, objects and null are stored as JSON text.
+        _ => SqlType::Text,
+    }
+}
+
+/// Convert a serialised field value into a [`SqlValue`].
+fn json_to_sql(value: &Value) -> SqlValue {
+    match value {
+        Value::Null => SqlValue::Null,
+        Value::Bool(b) => SqlValue::Integer(*b as i64),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                SqlValue::Integer(i)
+            } else if let Some(u) = n.as_u64() {
+                SqlValue::Integer(u as i64)
+            } else {
+                SqlValue::Real(n.as_f64().unwrap_or(0.0))
+            }
+        }
+        Value::String(s) => SqlValue::Text(s.clone()),
+        // Arrays / objects: keep the JSON text representation.
+        other => SqlValue::Text(other.to_string()),
+    }
+}
+
+/// Convert `PascalCase` / `camelCase` to `snake_case`.
+fn to_snake_case(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for (i, ch) in s.char_indices() {
+        if ch.is_ascii_uppercase() {
+            if i != 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}

--- a/src/persistence/record.rs
+++ b/src/persistence/record.rs
@@ -183,3 +183,71 @@ fn to_snake_case(s: &str) -> String {
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn snake_case_splits_on_each_uppercase() {
+        assert_eq!(to_snake_case("ValueSet"), "value_set");
+        assert_eq!(to_snake_case("Transfer"), "transfer");
+        assert_eq!(to_snake_case("ERC20Transfer"), "e_r_c20_transfer");
+        // camelCase: no leading underscore.
+        assert_eq!(to_snake_case("valueSet"), "value_set");
+        // Already snake / single word are unchanged.
+        assert_eq!(to_snake_case("value"), "value");
+        assert_eq!(to_snake_case("already_snake"), "already_snake");
+        assert_eq!(to_snake_case(""), "");
+    }
+
+    #[test]
+    fn infer_type_is_a_best_guess_from_json() {
+        assert_eq!(infer_type(&json!(true)), SqlType::Integer);
+        assert_eq!(infer_type(&json!(7)), SqlType::Integer);
+        assert_eq!(infer_type(&json!(u64::MAX)), SqlType::Integer);
+        assert_eq!(infer_type(&json!(1.5)), SqlType::Real);
+        assert_eq!(infer_type(&json!("0x2a")), SqlType::Text);
+        // Arrays, objects and null fall back to JSON text.
+        assert_eq!(infer_type(&json!([1, 2])), SqlType::Text);
+        assert_eq!(infer_type(&json!({"a": 1})), SqlType::Text);
+        assert_eq!(infer_type(&json!(null)), SqlType::Text);
+    }
+
+    #[test]
+    fn json_to_sql_converts_scalars_directly() {
+        assert_eq!(json_to_sql(&json!(null)), SqlValue::Null);
+        assert_eq!(json_to_sql(&json!(true)), SqlValue::Integer(1));
+        assert_eq!(json_to_sql(&json!(false)), SqlValue::Integer(0));
+        assert_eq!(json_to_sql(&json!(-7)), SqlValue::Integer(-7));
+        assert_eq!(json_to_sql(&json!(1.5)), SqlValue::Real(1.5));
+        assert_eq!(
+            json_to_sql(&json!("0x2a")),
+            SqlValue::Text("0x2a".to_string())
+        );
+    }
+
+    #[test]
+    fn json_to_sql_keeps_a_u64_above_i64_max_as_integer() {
+        // u64::MAX does not fit in i64; it is reinterpreted via `as i64` rather
+        // than spilling to Real, matching SQLite's 64-bit integer storage.
+        let big = u64::MAX;
+        assert_eq!(
+            json_to_sql(&json!(big)),
+            SqlValue::Integer(big as i64) // == -1
+        );
+    }
+
+    #[test]
+    fn json_to_sql_stores_compound_values_as_json_text() {
+        assert_eq!(
+            json_to_sql(&json!([1, 2])),
+            SqlValue::Text("[1,2]".to_string())
+        );
+        assert_eq!(
+            json_to_sql(&json!({"a": 1})),
+            SqlValue::Text("{\"a\":1}".to_string())
+        );
+    }
+}

--- a/src/persistence/schema.rs
+++ b/src/persistence/schema.rs
@@ -1,0 +1,81 @@
+//! Table schema and row value types shared by every [`Store`](super::Store).
+
+/// A SQL column type. SQLite is dynamically typed, so these act as type
+/// affinities / a best-guess mapping from event field types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqlType {
+    Integer,
+    Real,
+    Text,
+    Blob,
+    Numeric,
+}
+
+impl SqlType {
+    /// The SQL keyword used in a `CREATE TABLE` column definition.
+    pub fn sql(&self) -> &'static str {
+        match self {
+            SqlType::Integer => "INTEGER",
+            SqlType::Real => "REAL",
+            SqlType::Text => "TEXT",
+            SqlType::Blob => "BLOB",
+            SqlType::Numeric => "NUMERIC",
+        }
+    }
+}
+
+/// A single column in a [`TableSchema`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Column {
+    pub name: String,
+    pub ty: SqlType,
+}
+
+impl Column {
+    pub fn new(name: impl Into<String>, ty: SqlType) -> Self {
+        Self {
+            name: name.into(),
+            ty,
+        }
+    }
+}
+
+/// The schema for one event's table: a table name and its event-field columns.
+///
+/// The `block_number` column is implicit — every [`Store`](super::Store) adds
+/// it — so a schema describes only the event's own fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableSchema {
+    pub table: String,
+    pub columns: Vec<Column>,
+}
+
+impl TableSchema {
+    pub fn new(table: impl Into<String>) -> Self {
+        Self {
+            table: table.into(),
+            columns: Vec::new(),
+        }
+    }
+
+    /// Append a column (builder style).
+    pub fn col(mut self, name: impl Into<String>, ty: SqlType) -> Self {
+        self.columns.push(Column::new(name, ty));
+        self
+    }
+}
+
+/// A scalar value bound into / read out of a SQL cell.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SqlValue {
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    Blob(Vec<u8>),
+    Null,
+}
+
+/// One row's worth of event-field values, ordered to match
+/// [`TableSchema::columns`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct Row(pub Vec<SqlValue>);

--- a/src/persistence/schema.rs
+++ b/src/persistence/schema.rs
@@ -79,3 +79,54 @@ pub enum SqlValue {
 /// [`TableSchema::columns`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct Row(pub Vec<SqlValue>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sql_type_maps_to_create_table_keyword() {
+        assert_eq!(SqlType::Integer.sql(), "INTEGER");
+        assert_eq!(SqlType::Real.sql(), "REAL");
+        assert_eq!(SqlType::Text.sql(), "TEXT");
+        assert_eq!(SqlType::Blob.sql(), "BLOB");
+        assert_eq!(SqlType::Numeric.sql(), "NUMERIC");
+    }
+
+    #[test]
+    fn column_new_accepts_str_and_string() {
+        assert_eq!(
+            Column::new("amount", SqlType::Numeric),
+            Column {
+                name: "amount".to_string(),
+                ty: SqlType::Numeric,
+            }
+        );
+        // `impl Into<String>` so an owned String works too.
+        assert_eq!(
+            Column::new(String::from("amount"), SqlType::Numeric).name,
+            "amount"
+        );
+    }
+
+    #[test]
+    fn table_schema_builder_appends_columns_in_order() {
+        let schema = TableSchema::new("transfer")
+            .col("from", SqlType::Text)
+            .col("amount", SqlType::Numeric);
+
+        assert_eq!(schema.table, "transfer");
+        assert_eq!(
+            schema.columns,
+            vec![
+                Column::new("from", SqlType::Text),
+                Column::new("amount", SqlType::Numeric),
+            ]
+        );
+    }
+
+    #[test]
+    fn new_table_schema_starts_empty() {
+        assert!(TableSchema::new("transfer").columns.is_empty());
+    }
+}

--- a/src/persistence/sqlite.rs
+++ b/src/persistence/sqlite.rs
@@ -1,0 +1,208 @@
+//! A [`Store`] backed by SQLite via `sqlx`.
+
+use std::any::TypeId;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::RwLock;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions, SqliteRow};
+use sqlx::{Arguments, Row as _, sqlite::SqliteArguments};
+
+use super::schema::{Row, SqlType, SqlValue, TableSchema};
+use super::store::Store;
+
+/// A SQLite-backed [`Store`].
+pub struct SqliteStore {
+    pool: SqlitePool,
+    overrides: RwLock<HashMap<TypeId, TableSchema>>,
+}
+
+impl SqliteStore {
+    /// Open (creating if missing) a SQLite database at `url`.
+    ///
+    /// Use `"sqlite::memory:"` for an ephemeral in-memory database. A single
+    /// connection is used so an in-memory database is shared across calls and
+    /// every write sees a consistent view.
+    pub async fn connect(url: &str) -> Result<Self> {
+        let opts = SqliteConnectOptions::from_str(url)?.create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
+            .await?;
+        Ok(Self {
+            pool,
+            overrides: RwLock::new(HashMap::new()),
+        })
+    }
+
+    /// Override the best-guess schema for event type `E` with `schema`. Events
+    /// of type `E` are then persisted under `schema`'s table name and columns.
+    pub fn override_schema<E: 'static>(&self, schema: TableSchema) {
+        self.overrides
+            .write()
+            .expect("schema override lock poisoned")
+            .insert(TypeId::of::<E>(), schema);
+    }
+}
+
+/// Quote a SQL identifier (table/column name) for inclusion in a statement.
+fn quote_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+/// Bind a [`SqlValue`] onto a `sqlx` argument list.
+fn bind_value(args: &mut SqliteArguments<'_>, value: &SqlValue) -> Result<()> {
+    match value {
+        SqlValue::Integer(i) => args.add(*i),
+        SqlValue::Real(r) => args.add(*r),
+        SqlValue::Text(s) => args.add(s.clone()),
+        SqlValue::Blob(b) => args.add(b.clone()),
+        SqlValue::Null => args.add(Option::<i64>::None),
+    }
+    .map_err(|e| anyhow::anyhow!("failed to bind value: {e}"))
+}
+
+/// Decode column `idx` of `row` into a [`SqlValue`] per its declared type.
+fn decode_value(row: &SqliteRow, idx: usize, ty: SqlType) -> Result<SqlValue> {
+    let value = match ty {
+        SqlType::Integer => SqlValue::Integer(row.try_get::<i64, _>(idx)?),
+        SqlType::Real => SqlValue::Real(row.try_get::<f64, _>(idx)?),
+        SqlType::Text | SqlType::Numeric => SqlValue::Text(row.try_get::<String, _>(idx)?),
+        SqlType::Blob => SqlValue::Blob(row.try_get::<Vec<u8>, _>(idx)?),
+    };
+    Ok(value)
+}
+
+#[async_trait]
+impl Store for SqliteStore {
+    async fn write_block(&self, schema: &TableSchema, block: u64, rows: Vec<Row>) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+
+        // Progress table tracking the last processed block per event table.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS _artemis_progress \
+             (table_name TEXT PRIMARY KEY, last_block INTEGER NOT NULL)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        // Create the table on demand: an implicit block_number column plus one
+        // column per event field.
+        let mut defs = vec!["block_number INTEGER NOT NULL".to_string()];
+        for c in &schema.columns {
+            defs.push(format!("{} {}", quote_ident(&c.name), c.ty.sql()));
+        }
+        let create = format!(
+            "CREATE TABLE IF NOT EXISTS {} ({})",
+            quote_ident(&schema.table),
+            defs.join(", ")
+        );
+        sqlx::query(&create).execute(&mut *tx).await?;
+
+        // Insert every row in the block.
+        let mut col_names = vec!["block_number".to_string()];
+        col_names.extend(schema.columns.iter().map(|c| quote_ident(&c.name)));
+        let placeholders = vec!["?"; col_names.len()].join(", ");
+        let insert = format!(
+            "INSERT INTO {} ({}) VALUES ({})",
+            quote_ident(&schema.table),
+            col_names.join(", "),
+            placeholders
+        );
+
+        for row in &rows {
+            // Guard against shape mismatches: sqlx silently binds NULL for a
+            // short argument list, so a row that does not match the schema
+            // would corrupt the table rather than error. Bail (rolling the
+            // transaction back) instead.
+            if row.0.len() != schema.columns.len() {
+                anyhow::bail!(
+                    "row has {} values but table {:?} has {} columns",
+                    row.0.len(),
+                    schema.table,
+                    schema.columns.len()
+                );
+            }
+            let mut args = SqliteArguments::default();
+            bind_value(&mut args, &SqlValue::Integer(block as i64))?;
+            for value in &row.0 {
+                bind_value(&mut args, value)?;
+            }
+            sqlx::query_with(&insert, args).execute(&mut *tx).await?;
+        }
+
+        // Advance the last processed block in the same transaction.
+        sqlx::query(
+            "INSERT INTO _artemis_progress (table_name, last_block) VALUES (?, ?) \
+             ON CONFLICT(table_name) DO UPDATE SET last_block = MAX(last_block, excluded.last_block)",
+        )
+        .bind(&schema.table)
+        .bind(block as i64)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn last_block(&self, table: &str) -> Result<Option<u64>> {
+        let row = match sqlx::query("SELECT last_block FROM _artemis_progress WHERE table_name = ?")
+            .bind(table)
+            .fetch_optional(&self.pool)
+            .await
+        {
+            Ok(row) => row,
+            // No progress table means nothing has ever been written.
+            Err(sqlx::Error::Database(e)) if e.message().contains("no such table") => None,
+            Err(e) => return Err(e.into()),
+        };
+        Ok(row.map(|r| r.get::<i64, _>(0) as u64))
+    }
+
+    async fn replay(&self, schema: &TableSchema, to: u64) -> Result<Vec<Row>> {
+        let select_cols = schema
+            .columns
+            .iter()
+            .map(|c| quote_ident(&c.name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT {} FROM {} WHERE block_number <= ? ORDER BY block_number ASC, rowid ASC",
+            select_cols,
+            quote_ident(&schema.table)
+        );
+
+        let sqlx_rows = match sqlx::query(&sql)
+            .bind(to as i64)
+            .fetch_all(&self.pool)
+            .await
+        {
+            Ok(rows) => rows,
+            // A missing table means nothing has been stored yet.
+            Err(sqlx::Error::Database(e)) if e.message().contains("no such table") => {
+                return Ok(Vec::new());
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+        let mut out = Vec::with_capacity(sqlx_rows.len());
+        for r in &sqlx_rows {
+            let mut values = Vec::with_capacity(schema.columns.len());
+            for (idx, c) in schema.columns.iter().enumerate() {
+                values.push(decode_value(r, idx, c.ty)?);
+            }
+            out.push(Row(values));
+        }
+        Ok(out)
+    }
+
+    fn schema_override(&self, type_id: TypeId) -> Option<TableSchema> {
+        self.overrides
+            .read()
+            .expect("schema override lock poisoned")
+            .get(&type_id)
+            .cloned()
+    }
+}

--- a/src/persistence/store.rs
+++ b/src/persistence/store.rs
@@ -1,0 +1,57 @@
+//! The [`Store`] trait: a SQL backend for indexed events.
+
+use std::any::TypeId;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::schema::{Row, TableSchema};
+
+/// A storage backend that records indexed events, one table per event type.
+///
+/// Implementations persist a whole block's rows transactionally and track the
+/// last processed block, so a subscription can be resumed without gaps or
+/// double-writes.
+#[async_trait]
+pub trait Store: Send + Sync {
+    /// Persist every row emitted in `block` for `schema`'s table, creating the
+    /// table if needed, and advance the last processed block — all in a single
+    /// transaction.
+    async fn write_block(&self, schema: &TableSchema, block: u64, rows: Vec<Row>) -> Result<()>;
+
+    /// The last processed block for `table`, or `None` if nothing is stored.
+    async fn last_block(&self, table: &str) -> Result<Option<u64>>;
+
+    /// Replay stored rows for `schema`'s table with `block_number <= to`, in
+    /// ascending block order. Returns an empty vec if the table does not exist.
+    async fn replay(&self, schema: &TableSchema, to: u64) -> Result<Vec<Row>>;
+
+    /// The registered schema override for the event type identified by
+    /// `type_id`, if any. Defaults to `None` (use the best-guess schema).
+    fn schema_override(&self, type_id: TypeId) -> Option<TableSchema> {
+        let _ = type_id;
+        None
+    }
+}
+
+/// Blanket impl so a shared [`Arc<S>`] can be used wherever a [`Store`] is
+/// expected — handy for sharing one store across collectors and assertions.
+#[async_trait]
+impl<T: Store + ?Sized> Store for Arc<T> {
+    async fn write_block(&self, schema: &TableSchema, block: u64, rows: Vec<Row>) -> Result<()> {
+        (**self).write_block(schema, block, rows).await
+    }
+
+    async fn last_block(&self, table: &str) -> Result<Option<u64>> {
+        (**self).last_block(table).await
+    }
+
+    async fn replay(&self, schema: &TableSchema, to: u64) -> Result<Vec<Row>> {
+        (**self).replay(schema, to).await
+    }
+
+    fn schema_override(&self, type_id: TypeId) -> Option<TableSchema> {
+        (**self).schema_override(type_id)
+    }
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -583,7 +583,7 @@ mod engine_tests {
 
         #[async_trait]
         impl Collector<u32> for EndingCollector {
-            async fn get_event_stream(&self) -> Result<CollectorStream<'_, u32>> {
+            async fn subscribe(&self) -> Result<CollectorStream<'_, u32>> {
                 Ok(Box::pin(futures::stream::empty::<u32>()))
             }
         }
@@ -631,7 +631,7 @@ mod engine_tests {
 
         #[async_trait]
         impl Collector<u32> for EndingCollector {
-            async fn get_event_stream(&self) -> Result<CollectorStream<'_, u32>> {
+            async fn subscribe(&self) -> Result<CollectorStream<'_, u32>> {
                 Ok(Box::pin(futures::stream::empty::<u32>()))
             }
         }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -306,7 +306,7 @@ async fn test_complete_flow() {
     impl Executor<NumberAction> for NumberExecutor {
         async fn execute(&mut self, action: NumberAction) -> Result<()> {
             // Send response: true if number is even, false if odd
-            let success = action.number % 2 == 0;
+            let success = action.number.is_multiple_of(2);
             action.response_tx.send(success).unwrap();
             Ok(())
         }

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use alloy::node_bindings::{Anvil, AnvilInstance};
-use alloy::primitives::U256;
+use alloy::primitives::{Address, U256};
 use alloy::providers::{Provider, ProviderBuilder, WsConnect};
 use alloy::signers::local::PrivateKeySigner;
 use alloy::sol;
@@ -11,7 +11,8 @@ use anyhow::Result;
 use artemis_light::collectors::EventCollector;
 use artemis_light::persistence::{
     Column, PersistExt, PersistableCollector, Row, SqlType, SqlValue, SqliteStore, Store,
-    TableSchema, derive, derive_record, table_name,
+    TableSchema, derive, derive_record, derive_record_with, from_payload, payload_schema,
+    table_name,
 };
 use artemis_light::types::{Collector, CollectorStream};
 use async_trait::async_trait;
@@ -33,6 +34,20 @@ sol! {
 }
 
 use Emitter::ValueSet;
+
+sol! {
+    // A two-field event used to exercise multi-column schema derivation and the
+    // override field-alignment logic (rename-away, missing-field, reorder).
+    #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
+    event Transfer(address indexed from, uint256 amount);
+}
+
+fn transfer_event() -> Transfer {
+    Transfer {
+        from: Address::ZERO,
+        amount: U256::from(1000),
+    }
+}
 
 /// Spawns Anvil (1s blocks) and a WS provider with a wallet signer.
 async fn spawn_anvil_with_signer() -> Result<(impl Provider + Clone, AnvilInstance)> {
@@ -224,6 +239,80 @@ async fn derive_schema_uses_event_name_and_field_names() {
     let (schema, _row) = derive(&event).unwrap();
     assert_eq!(schema.table, "value_set");
     assert_eq!(schema.columns, vec![Column::new("value", SqlType::Text)]);
+}
+
+/// A multi-field event derives one column per field, named after the field and
+/// ordered deterministically (by field name), with values aligned to columns.
+#[test]
+fn derive_maps_each_event_field_to_a_column() {
+    let (schema, Row(values)) = derive(&transfer_event()).unwrap();
+
+    assert_eq!(schema.table, "transfer");
+    let names: Vec<&str> = schema.columns.iter().map(|c| c.name.as_str()).collect();
+    // Sorted by field name: `amount` before `from`.
+    assert_eq!(names, vec!["amount", "from"]);
+    assert_eq!(values.len(), 2);
+}
+
+/// `derive_record` appends an implicit `_payload` column holding the event's
+/// full JSON, and that payload round-trips back to an equal event.
+#[test]
+fn derive_record_appends_payload_column_that_round_trips() {
+    let event = transfer_event();
+    let (schema, Row(values)) = derive_record(&event).unwrap();
+
+    let names: Vec<&str> = schema.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, vec!["amount", "from", "_payload"]);
+
+    let SqlValue::Text(payload) = values.last().unwrap() else {
+        panic!("payload column should be text");
+    };
+    let restored: Transfer = from_payload(payload).unwrap();
+    assert_eq!(restored, event);
+}
+
+/// A schema override redirects the table, renames-away unlisted fields, fills
+/// columns with no matching field with `NULL`, and still appends `_payload`.
+#[test]
+fn derive_record_with_override_aligns_values_by_column_name() {
+    let event = transfer_event();
+    let override_ = TableSchema::new("transfers_custom")
+        .col("amount", SqlType::Numeric) // kept and retyped
+        .col("missing", SqlType::Text); // no matching event field
+
+    let (schema, Row(values)) = derive_record_with(&event, Some(&override_)).unwrap();
+
+    // Table and column set follow the override, with `_payload` appended; the
+    // `from` field is renamed-away because the override does not list it.
+    assert_eq!(schema.table, "transfers_custom");
+    let names: Vec<&str> = schema.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, vec!["amount", "missing", "_payload"]);
+
+    // `amount` is populated; `missing` has no field so it is NULL.
+    assert!(matches!(values[0], SqlValue::Text(_)));
+    assert_eq!(values[1], SqlValue::Null);
+
+    // The payload is unaffected by the override and still round-trips fully.
+    let SqlValue::Text(payload) = values.last().unwrap() else {
+        panic!("payload column should be text");
+    };
+    assert_eq!(from_payload::<Transfer>(payload).unwrap(), event);
+}
+
+/// `payload_schema` describes the read-back shape — table name plus the single
+/// `_payload` column — without needing an event instance.
+#[test]
+fn payload_schema_is_table_plus_payload_column() {
+    let schema = payload_schema::<Transfer>();
+    assert_eq!(schema.table, "transfer");
+    assert_eq!(schema.columns, vec![Column::new("_payload", SqlType::Text)]);
+}
+
+/// A stored payload that is not valid JSON for the event type is a hard error,
+/// never a silently dropped row.
+#[test]
+fn from_payload_errors_on_unreadable_text() {
+    assert!(from_payload::<Transfer>("not a valid payload").is_err());
 }
 
 /// Slice 7: a `Persisted` collector records live events one transaction per

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -1,6 +1,7 @@
 //! Behaviour tests for the persistence layer, exercised through its public API.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use alloy::node_bindings::{Anvil, AnvilInstance};
 use alloy::primitives::{Address, U256};
@@ -64,6 +65,9 @@ struct FakeCollector {
     live: Vec<(u64, u64)>,
     backfill: Vec<(u64, u64)>,
     tip: u64,
+    /// Number of leading `query_range` calls that should error before the rest
+    /// succeed — used to simulate a transient RPC backfill failure.
+    query_range_fails: AtomicUsize,
 }
 
 impl FakeCollector {
@@ -77,6 +81,10 @@ impl FakeCollector {
     }
     fn tip(mut self, tip: u64) -> Self {
         self.tip = tip;
+        self
+    }
+    fn fail_query_range_times(self, n: usize) -> Self {
+        self.query_range_fails.store(n, Ordering::SeqCst);
         self
     }
 }
@@ -103,6 +111,12 @@ impl PersistableCollector<ValueSet> for FakeCollector {
         from: u64,
         to: u64,
     ) -> Result<CollectorStream<'_, (u64, ValueSet)>> {
+        let remaining = self.query_range_fails.load(Ordering::SeqCst);
+        if remaining > 0 {
+            self.query_range_fails
+                .store(remaining - 1, Ordering::SeqCst);
+            anyhow::bail!("simulated query_range failure");
+        }
         let events: Vec<_> = self
             .backfill
             .iter()
@@ -521,6 +535,35 @@ async fn persisted_does_not_replay_history_on_resubscribe() {
     // Reconnect: stored history must NOT be replayed again — only live flows.
     let second: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
     assert_eq!(second, vec![value_event(3)]);
+}
+
+/// A failed subscribe must not consume the replay-once flag. If a fallible step
+/// after the DB replay (here the RPC backfill query) errors, the engine retries
+/// `subscribe`; that retry must still replay the stored history rather than skip
+/// it — otherwise the archive never reaches strategies and is lost for good.
+#[tokio::test]
+async fn failed_subscribe_does_not_consume_replay() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+    seed(&store, 5, 1).await;
+    seed(&store, 6, 2).await;
+
+    // The first backfill query errors; subsequent ones succeed.
+    let collector = FakeCollector::default()
+        .live(vec![(7, 3)])
+        .tip(6)
+        .fail_query_range_times(1);
+    let persisted = collector.with_persistence(store.clone());
+
+    // First subscribe fails because the RPC backfill query errors.
+    assert!(
+        persisted.subscribe().await.is_err(),
+        "a failing backfill query must fail the subscribe"
+    );
+
+    // Retry: the stored history (1, 2) must still be replayed — the failed
+    // attempt must not have flipped the replay-once flag.
+    let events: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+    assert_eq!(events, vec![value_event(1), value_event(2), value_event(3)]);
 }
 
 /// A store that fails `write_block` for one specific block, delegating

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -1,0 +1,476 @@
+//! Behaviour tests for the persistence layer, exercised through its public API.
+
+use std::sync::Arc;
+
+use alloy::node_bindings::{Anvil, AnvilInstance};
+use alloy::primitives::U256;
+use alloy::providers::{Provider, ProviderBuilder, WsConnect};
+use alloy::signers::local::PrivateKeySigner;
+use alloy::sol;
+use anyhow::Result;
+use artemis_light::collectors::EventCollector;
+use artemis_light::persistence::{
+    Column, PersistExt, PersistableCollector, Row, SqlType, SqlValue, SqliteStore, Store,
+    TableSchema, derive, derive_record, table_name,
+};
+use artemis_light::types::{Collector, CollectorStream};
+use async_trait::async_trait;
+use futures::StreamExt;
+
+sol! {
+    #[sol(rpc, bytecode = "6080604052348015600e575f5ffd5b5060d980601a5f395ff3fe6080604052348015600e575f5ffd5b50600436106030575f3560e01c80633fa4f2451460345780635524107714604d575b5f5ffd5b603b5f5481565b60405190815260200160405180910390f35b605c6058366004608d565b605e565b005b5f81815560405182917f012c78e2b84325878b1bd9d250d772cfe5bda7722d795f45036fa5e1e6e303fc91a250565b5f60208284031215609c575f5ffd5b503591905056fea264697066735822122050fddb04e40945ebc7c51aef06d27a86c4aa98943b773d9ffdc789caf784441064736f6c634300081e0033")]
+    contract Emitter {
+        uint256 public value;
+
+        #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
+        event ValueSet(uint256 indexed value);
+
+        function setValue(uint256 _value) external {
+            value = _value;
+            emit ValueSet(_value);
+        }
+    }
+}
+
+use Emitter::ValueSet;
+
+/// Spawns Anvil (1s blocks) and a WS provider with a wallet signer.
+async fn spawn_anvil_with_signer() -> Result<(impl Provider + Clone, AnvilInstance)> {
+    let anvil = Anvil::new().block_time(1).chain_id(1337).try_spawn()?;
+    let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
+    let ws = WsConnect::new(anvil.ws_endpoint());
+    let provider = ProviderBuilder::new().wallet(signer).connect_ws(ws).await?;
+    Ok((provider, anvil))
+}
+
+/// A scripted [`PersistableCollector`] used to drive `Persisted` deterministically.
+#[derive(Default)]
+struct FakeCollector {
+    live: Vec<(u64, u64)>,
+    backfill: Vec<(u64, u64)>,
+    tip: u64,
+}
+
+impl FakeCollector {
+    fn live(mut self, events: Vec<(u64, u64)>) -> Self {
+        self.live = events;
+        self
+    }
+    fn backfill(mut self, events: Vec<(u64, u64)>) -> Self {
+        self.backfill = events;
+        self
+    }
+    fn tip(mut self, tip: u64) -> Self {
+        self.tip = tip;
+        self
+    }
+}
+
+fn value_event(value: u64) -> ValueSet {
+    ValueSet {
+        value: U256::from(value),
+    }
+}
+
+#[async_trait]
+impl PersistableCollector<ValueSet> for FakeCollector {
+    async fn subscribe_indexed(&self) -> Result<CollectorStream<'_, (u64, ValueSet)>> {
+        let events: Vec<_> = self
+            .live
+            .iter()
+            .map(|&(b, v)| (b, value_event(v)))
+            .collect();
+        Ok(Box::pin(futures::stream::iter(events)))
+    }
+
+    async fn query_range(
+        &self,
+        from: u64,
+        to: u64,
+    ) -> Result<CollectorStream<'_, (u64, ValueSet)>> {
+        let events: Vec<_> = self
+            .backfill
+            .iter()
+            .filter(|&&(b, _)| b >= from && b <= to)
+            .map(|&(b, v)| (b, value_event(v)))
+            .collect();
+        Ok(Box::pin(futures::stream::iter(events)))
+    }
+
+    async fn tip(&self) -> Result<u64> {
+        Ok(self.tip)
+    }
+}
+
+/// The `value` field of each persisted row, in stored order.
+async fn stored_values(store: &SqliteStore) -> Vec<String> {
+    let schema = value_set_schema();
+    store
+        .replay(&schema, i64::MAX as u64)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|Row(mut cols)| match cols.remove(0) {
+            SqlValue::Text(s) => s,
+            other => panic!("unexpected value column: {other:?}"),
+        })
+        .collect()
+}
+
+/// A one-column `value_set` schema reused across tests.
+fn value_set_schema() -> TableSchema {
+    TableSchema {
+        table: "value_set".into(),
+        columns: vec![Column::new("value", SqlType::Text)],
+    }
+}
+
+/// Slice 1: a written block can be read back via `replay`.
+#[tokio::test]
+async fn write_block_then_replay_reads_rows_back() {
+    let store = SqliteStore::connect("sqlite::memory:").await.unwrap();
+    let schema = value_set_schema();
+
+    store
+        .write_block(
+            &schema,
+            7,
+            vec![
+                Row(vec![SqlValue::Text("0x2a".into())]),
+                Row(vec![SqlValue::Text("0x2b".into())]),
+            ],
+        )
+        .await
+        .unwrap();
+
+    let rows = store.replay(&schema, 100).await.unwrap();
+    assert_eq!(
+        rows,
+        vec![
+            Row(vec![SqlValue::Text("0x2a".into())]),
+            Row(vec![SqlValue::Text("0x2b".into())]),
+        ]
+    );
+}
+
+/// Slice 2: `last_block` reports the highest written block, `None` when empty.
+#[tokio::test]
+async fn last_block_tracks_highest_written_block() {
+    let store = SqliteStore::connect("sqlite::memory:").await.unwrap();
+    let schema = value_set_schema();
+
+    // Nothing stored yet.
+    assert_eq!(store.last_block(&schema.table).await.unwrap(), None);
+
+    store
+        .write_block(&schema, 5, vec![Row(vec![SqlValue::Text("a".into())])])
+        .await
+        .unwrap();
+    assert_eq!(store.last_block(&schema.table).await.unwrap(), Some(5));
+
+    store
+        .write_block(&schema, 9, vec![Row(vec![SqlValue::Text("b".into())])])
+        .await
+        .unwrap();
+    assert_eq!(store.last_block(&schema.table).await.unwrap(), Some(9));
+}
+
+/// Slice 3: a failing row in a batch rolls back the whole block, leaving prior
+/// committed data and the last processed block untouched.
+#[tokio::test]
+async fn write_block_is_atomic_on_failure() {
+    let store = SqliteStore::connect("sqlite::memory:").await.unwrap();
+    let schema = value_set_schema(); // one column
+
+    // Block 5 is written cleanly.
+    store
+        .write_block(&schema, 5, vec![Row(vec![SqlValue::Text("ok".into())])])
+        .await
+        .unwrap();
+
+    // Block 9's second row has too few values for the schema, so its INSERT
+    // fails partway through the batch.
+    let result = store
+        .write_block(
+            &schema,
+            9,
+            vec![
+                Row(vec![SqlValue::Text("good".into())]),
+                Row(vec![]), // missing the `value` column
+            ],
+        )
+        .await;
+    assert!(result.is_err(), "malformed batch should fail");
+
+    // Block 9 rolled back entirely: only block 5's row survives and the
+    // progress marker still points at block 5.
+    assert_eq!(
+        store.replay(&schema, 100).await.unwrap(),
+        vec![Row(vec![SqlValue::Text("ok".into())])]
+    );
+    assert_eq!(store.last_block(&schema.table).await.unwrap(), Some(5));
+}
+
+/// Slice 4: schema is derived from a Serialize+SolEvent type — table name from
+/// the Solidity signature, columns from the event's field names.
+#[tokio::test]
+async fn derive_schema_uses_event_name_and_field_names() {
+    let event = ValueSet {
+        value: U256::from(42),
+    };
+
+    assert_eq!(table_name::<ValueSet>(), "value_set");
+
+    let (schema, _row) = derive(&event).unwrap();
+    assert_eq!(schema.table, "value_set");
+    assert_eq!(schema.columns, vec![Column::new("value", SqlType::Text)]);
+}
+
+/// Slice 7: a `Persisted` collector records live events one transaction per
+/// complete block, while passing the plain events downstream. The final
+/// in-progress block stays unflushed (no higher block seen yet), so a restart
+/// re-fetches it.
+#[tokio::test]
+async fn persisted_records_live_events_per_complete_block() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+
+    // Two events in block 10, one in block 11 (the open tip).
+    let collector = FakeCollector::default().live(vec![(10, 1), (10, 2), (11, 3)]);
+    let persisted = collector.with_persistence(store.clone());
+
+    let events: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+
+    // Downstream sees every event, in order.
+    assert_eq!(events, vec![value_event(1), value_event(2), value_event(3)]);
+
+    // Only block 10 is complete and flushed; block 11 is still open.
+    assert_eq!(store.last_block("value_set").await.unwrap(), Some(10));
+    assert_eq!(
+        stored_values(&store).await,
+        vec!["0x1".to_string(), "0x2".to_string()]
+    );
+}
+
+/// Persist one event at `block` as if a previous run had stored it.
+async fn seed(store: &SqliteStore, block: u64, value: u64) {
+    let (schema, row) = derive_record(&value_event(value)).unwrap();
+    store.write_block(&schema, block, vec![row]).await.unwrap();
+}
+
+/// Slice 8: on subscribe, stored history is replayed first (reconstructed from
+/// the database), then the live tip follows — a single chained stream.
+#[tokio::test]
+async fn persisted_replays_db_then_live() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+    seed(&store, 5, 1).await;
+    seed(&store, 6, 2).await;
+
+    // Tip is the last stored block, so there is no RPC gap to backfill; the
+    // live stream carries the next event.
+    let collector = FakeCollector::default().live(vec![(7, 3)]).tip(6);
+    let persisted = collector.with_persistence(store.clone());
+
+    let events: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+    assert_eq!(events, vec![value_event(1), value_event(2), value_event(3)]);
+}
+
+/// Slice 9: the RPC gap between the last stored block and the tip is backfilled
+/// and chained as [DB replay][backfill][live]. Backfilled blocks are persisted;
+/// the open live block is not.
+#[tokio::test]
+async fn persisted_backfills_gap_between_last_stored_and_tip() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+    seed(&store, 5, 1).await; // last stored block = 5
+
+    // Tip is block 8: blocks 6 and 7 must be backfilled from the RPC node,
+    // then the live stream carries block 9.
+    let collector = FakeCollector::default()
+        .tip(8)
+        .backfill(vec![(6, 2), (7, 3)])
+        .live(vec![(9, 4)]);
+    let persisted = collector.with_persistence(store.clone());
+
+    let events: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+    assert_eq!(
+        events,
+        vec![
+            value_event(1),
+            value_event(2),
+            value_event(3),
+            value_event(4)
+        ]
+    );
+
+    // Backfilled blocks 6 and 7 are now stored (last complete block = 7); the
+    // open live block 9 is not flushed.
+    assert_eq!(store.last_block("value_set").await.unwrap(), Some(7));
+    assert_eq!(
+        stored_values(&store).await,
+        vec!["0x1".to_string(), "0x2".to_string(), "0x3".to_string()]
+    );
+}
+
+/// Slice 5: a schema override registered on the store changes the table name
+/// and column types; events persist under the overridden table.
+#[tokio::test]
+async fn override_schema_redirects_table_and_types() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+    store.override_schema::<ValueSet>(
+        TableSchema::new("custom_values").col("value", SqlType::Numeric),
+    );
+
+    // Block 1 complete, block 2 open.
+    let collector = FakeCollector::default().live(vec![(1, 7), (2, 8)]);
+    let persisted = collector.with_persistence(store.clone());
+    let _events: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+
+    // Progress and rows live under the overridden table, not the derived one.
+    assert_eq!(store.last_block("custom_values").await.unwrap(), Some(1));
+    assert_eq!(store.last_block("value_set").await.unwrap(), None);
+
+    let rows = store
+        .replay(
+            &TableSchema::new("custom_values").col("value", SqlType::Numeric),
+            i64::MAX as u64,
+        )
+        .await
+        .unwrap();
+    assert_eq!(rows, vec![Row(vec![SqlValue::Text("0x7".into())])]);
+}
+
+/// Slice 10: against a real chain, an `EventCollector` wrapped with persistence
+/// forwards typed events downstream and records them with their block numbers.
+#[tokio::test]
+async fn event_collector_with_persistence_records_against_anvil() {
+    let (provider, _anvil) = spawn_anvil_with_signer().await.unwrap();
+    let provider = Arc::new(provider);
+    let contract = Emitter::deploy(provider.clone()).await.unwrap();
+
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+    let collector = EventCollector::new(contract.ValueSet_filter());
+    let persisted = collector.with_persistence(store.clone());
+    let mut stream = persisted.subscribe().await.unwrap();
+
+    // Emit three events; with 1s blocks each mined tx lands in its own block.
+    for v in [11u64, 22, 33] {
+        contract
+            .setValue(U256::from(v))
+            .send()
+            .await
+            .unwrap()
+            .watch()
+            .await
+            .unwrap();
+    }
+
+    // Downstream receives the typed events with the right values.
+    let mut received = Vec::new();
+    for _ in 0..3 {
+        received.push(stream.next().await.unwrap().value);
+    }
+    assert_eq!(
+        received,
+        vec![U256::from(11), U256::from(22), U256::from(33)]
+    );
+
+    // The first two blocks are complete and persisted (block 33's is still
+    // open); their block numbers were recovered from the logs.
+    assert_eq!(
+        stored_values(&store).await,
+        vec!["0xb".to_string(), "0x16".to_string()]
+    );
+    assert!(store.last_block("value_set").await.unwrap().unwrap() > 0);
+}
+
+/// A store that fails `write_block` for one specific block, delegating
+/// everything else to an inner [`SqliteStore`].
+struct FlakyStore {
+    inner: Arc<SqliteStore>,
+    fail_at: u64,
+}
+
+#[async_trait]
+impl Store for FlakyStore {
+    async fn write_block(&self, schema: &TableSchema, block: u64, rows: Vec<Row>) -> Result<()> {
+        if block == self.fail_at {
+            anyhow::bail!("simulated write failure at block {block}");
+        }
+        self.inner.write_block(schema, block, rows).await
+    }
+    async fn last_block(&self, table: &str) -> Result<Option<u64>> {
+        self.inner.last_block(table).await
+    }
+    async fn replay(&self, schema: &TableSchema, to: u64) -> Result<Vec<Row>> {
+        self.inner.replay(schema, to).await
+    }
+}
+
+/// A failed block write halts persistence so the stored block height stays a
+/// gap-free prefix — a later block must not advance past the failed one. The
+/// event stream keeps flowing regardless.
+#[tokio::test]
+async fn persisted_halts_on_write_failure_to_avoid_gaps() {
+    let inner = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+    let store = FlakyStore {
+        inner: inner.clone(),
+        fail_at: 6,
+    };
+
+    // Blocks 5,6,7 complete (8 is the open tip). Block 6's write fails.
+    let collector = FakeCollector::default().live(vec![(5, 1), (6, 2), (7, 3), (8, 4)]);
+    let persisted = collector.with_persistence(store);
+
+    let events: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+    // Every event still reaches downstream.
+    assert_eq!(
+        events,
+        vec![
+            value_event(1),
+            value_event(2),
+            value_event(3),
+            value_event(4)
+        ]
+    );
+
+    // Only block 5 was persisted before the failure; block 7 must NOT advance
+    // the height past the gap at block 6.
+    assert_eq!(inner.last_block("value_set").await.unwrap(), Some(5));
+    assert_eq!(stored_values(&inner).await, vec!["0x1".to_string()]);
+}
+
+/// The backfill and live segments must be disjoint at the tip: an event that
+/// appears in both (because a live subscription re-delivers blocks `<= tip`)
+/// is emitted once downstream and stored once.
+#[tokio::test]
+async fn persisted_does_not_duplicate_events_at_backfill_live_boundary() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+    seed(&store, 5, 1).await; // last stored block = 5
+
+    // Tip is block 7. Block 7's event is delivered by BOTH the backfill query
+    // and the live subscription; block 8 is genuinely new.
+    let collector = FakeCollector::default()
+        .tip(7)
+        .backfill(vec![(6, 2), (7, 3)])
+        .live(vec![(7, 3), (8, 4)]);
+    let persisted = collector.with_persistence(store.clone());
+
+    let events: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+
+    // Block 7 (value 3) appears exactly once — not twice.
+    assert_eq!(
+        events,
+        vec![
+            value_event(1),
+            value_event(2),
+            value_event(3),
+            value_event(4)
+        ]
+    );
+
+    // Stored once each; the open live block 8 is not flushed.
+    assert_eq!(store.last_block("value_set").await.unwrap(), Some(7));
+    assert_eq!(
+        stored_values(&store).await,
+        vec!["0x1".to_string(), "0x2".to_string(), "0x3".to_string()]
+    );
+}

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -382,6 +382,58 @@ async fn event_collector_with_persistence_records_against_anvil() {
     assert!(store.last_block("value_set").await.unwrap().unwrap() > 0);
 }
 
+/// A stored payload that cannot be deserialized into its event type (a code or
+/// schema change, or corruption) must surface as a subscribe error rather than
+/// be silently dropped — strategies must never be handed a quietly truncated
+/// history.
+#[tokio::test]
+async fn persisted_replay_fails_loudly_on_unreadable_payload() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+
+    // Seed a row whose `_payload` is not valid JSON for `ValueSet`.
+    let payload_schema = TableSchema::new("value_set").col("_payload", SqlType::Text);
+    store
+        .write_block(
+            &payload_schema,
+            5,
+            vec![Row(vec![SqlValue::Text("not a valid payload".into())])],
+        )
+        .await
+        .unwrap();
+
+    let collector = FakeCollector::default().tip(5);
+    let persisted = collector.with_persistence(store.clone());
+
+    let result = persisted.subscribe().await;
+    assert!(
+        result.is_err(),
+        "an unreadable stored payload must fail the subscribe, not be silently skipped"
+    );
+}
+
+/// The engine re-subscribes after a stream ends. The full stored history must
+/// be replayed only on the first subscribe; a reconnect must not re-send the
+/// entire archive to strategies — the backfill segment already covers the gap.
+#[tokio::test]
+async fn persisted_does_not_replay_history_on_resubscribe() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+    seed(&store, 5, 1).await;
+    seed(&store, 6, 2).await;
+
+    // Tip equals the last stored block, so there is no gap to backfill; the
+    // live stream carries the next event.
+    let collector = FakeCollector::default().live(vec![(7, 3)]).tip(6);
+    let persisted = collector.with_persistence(store.clone());
+
+    // First subscribe: stored history (1, 2) replayed, then live (3).
+    let first: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+    assert_eq!(first, vec![value_event(1), value_event(2), value_event(3)]);
+
+    // Reconnect: stored history must NOT be replayed again — only live flows.
+    let second: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+    assert_eq!(second, vec![value_event(3)]);
+}
+
 /// A store that fails `write_block` for one specific block, delegating
 /// everything else to an inner [`SqliteStore`].
 struct FlakyStore {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New persistence path affects event ordering and restart correctness for strategies; behavior is heavily tested but adds sqlx/SQLite and subtle backfill/live boundary edge cases.
> 
> **Overview**
> Adds a **persistence** pipeline so block-aware collectors can survive restarts without re-syncing from genesis. Call **`.with_persistence(store)`** on collectors that implement **`PersistableCollector`** (notably **`EventCollector`**, which now exposes indexed live streams, **`query_range`**, and **`tip`**).
> 
> On **`subscribe`**, **`Persisted`** chains **replay** (SQLite archive, first subscribe only) → **RPC backfill** to the reported tip → **live** tail, while writing completed blocks transactionally via a pluggable **`Store`** (**`SqliteStore`** + **`sqlx`**). Schemas are derived from Solidity event names and serde fields, with optional overrides and a lossless **`_payload`** column for replay.
> 
> Also documents the feature in **README**, adds **`persistence_example`**, extensive **`tests/persistence`**, and pins Foundry to **`v1.7.1`** in CI to avoid GitHub rate-limit failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96dd96cba7f8154179bae9249124e366658753ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->