### PR TITLE
fix: exit process on WS disconnection instead of silent zombie

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -151,10 +151,7 @@ where
                 let mut retries = 0u32;
                 loop {
                     let mut event_stream = match collector.get_event_stream().await {
-                        Ok(s) => {
-                            retries = 0;
-                            s
-                        }
+                        Ok(s) => s,
                         Err(e) => {
                             retries += 1;
                             error!("collector stream creation failed (attempt {retries}): {e}");
@@ -166,13 +163,18 @@ where
                             continue;
                         }
                     };
+                    let mut received_events = false;
                     while let Some(event) = event_stream.next().await {
+                        received_events = true;
                         match event_sender.send(event) {
                             Ok(_) => {}
                             Err(e) => error!("error sending event: {e}"),
                         }
                     }
                     // Stream ended (WS disconnected)
+                    if received_events {
+                        retries = 0;
+                    }
                     retries += 1;
                     warn!("collector stream ended (attempt {retries}), retrying...");
                     if retries >= 3 {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,9 +1,10 @@
 use std::marker::PhantomData;
+use std::time::Duration;
 
 use tokio::sync::broadcast::{self, Sender};
 use tokio::task::JoinSet;
 use tokio_stream::StreamExt;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::types::{Collector, Executor, Strategy};
 
@@ -146,13 +147,39 @@ where
         for collector in self.collectors {
             let event_sender = event_sender.clone();
             set.spawn(async move {
-                info!("starting collector... ");
-                let mut event_stream = collector.get_event_stream().await.unwrap();
-                while let Some(event) = event_stream.next().await {
-                    match event_sender.send(event) {
-                        Ok(_) => {}
-                        Err(e) => error!("error sending event: {}", e),
+                info!("starting collector...");
+                let mut retries = 0u32;
+                loop {
+                    let mut event_stream = match collector.get_event_stream().await {
+                        Ok(s) => {
+                            retries = 0;
+                            s
+                        }
+                        Err(e) => {
+                            retries += 1;
+                            error!("collector stream creation failed (attempt {retries}): {e}");
+                            if retries >= 3 {
+                                error!("collector failed {retries} times, exiting process");
+                                std::process::exit(1);
+                            }
+                            tokio::time::sleep(Duration::from_secs(2u64.pow(retries))).await;
+                            continue;
+                        }
+                    };
+                    while let Some(event) = event_stream.next().await {
+                        match event_sender.send(event) {
+                            Ok(_) => {}
+                            Err(e) => error!("error sending event: {e}"),
+                        }
                     }
+                    // Stream ended (WS disconnected)
+                    retries += 1;
+                    warn!("collector stream ended (attempt {retries}), retrying...");
+                    if retries >= 3 {
+                        error!("collector stream ended {retries} times, exiting process");
+                        std::process::exit(1);
+                    }
+                    tokio::time::sleep(Duration::from_secs(2u64.pow(retries))).await;
                 }
             });
         }


### PR DESCRIPTION
    When a WebSocket connection drops, alloy's subscription stream returns
    None, causing the collector task to silently exit. The engine continues
    running but processes no new events — a zombie.

    Fix: wrap the collector loop with retry logic. On stream termination,
    attempt to recreate the stream. After 3 consecutive failures, exit the
    process so the orchestrator restarts it with a fresh sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes collector failure handling to include exponential backoff retries and forced process exit after repeated stream failures, which can affect runtime availability and restart behavior. Risk is moderate because it alters core engine lifecycle/error handling paths.
> 
> **Overview**
> Prevents the engine from becoming a silent “zombie” when a collector’s event stream ends (e.g., WebSocket disconnect).
> 
> Collectors now run in a retry loop that attempts to recreate the stream with exponential backoff, logs failures/terminations via `warn`/`error`, resets the counter after successful event reception, and **exits the process after 3 consecutive failures** so an external orchestrator can restart the service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e808e119b675fd543c2796e72482c7962551c65e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->