### PR TITLE
Move collector reconnect into a tested policy module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,44 @@
+# artemis-light
+
+Domain language for the event-processing pipeline (Collectors → Strategies → Executors, wired by the Engine). Records the terms a maintainer must share to talk about the pipeline precisely.
+
+## Language
+
+**Collector**:
+A source of events that turns an external stream (new blocks, pending txs, logs) into a stream of internal events.
+_Avoid_: listener, watcher, source
+
+**Strategy**:
+The opportunity logic — consumes events, produces a stream of actions.
+
+**Executor**:
+The sink that carries out actions in an external domain (submitting a tx, posting an order).
+
+**Engine**:
+The orchestrator that spawns every Collector, Strategy, and Executor as a task and fans events/actions between them over broadcast channels.
+
+**Reconnect Policy**:
+The per-Collector state machine that decides, after a stream is lost or never established, whether to **Retry** (after a backoff delay) or declare the Collector **Fatal** (unrecoverable). It owns the consecutive-failure counter and the backoff curve; it performs no I/O and keeps no clock — the driver supplies timing and cancellation.
+_Avoid_: retry handler, supervisor, backoff helper
+
+**Fatal**:
+The Reconnect Policy's verdict that a Collector cannot recover. The Engine responds by cancelling a dedicated, observe-only **fatal token** (the reason) and then the root token (tearing down every task), so the binary can tell a fatal shutdown apart from a caller-initiated one and restart the process with a fresh sync — never by killing the host process itself.
+_Avoid_: crash, panic, die
+
+## Relationships
+
+- An **Engine** drives many **Collectors**; each **Collector** task owns one **Reconnect Policy** instance.
+- A **Reconnect Policy** counts consecutive stream failures and resets that count only when its Collector delivers a real event.
+- A **Fatal** verdict cancels the observe-only fatal token, then the root token shared by all **Collector**, **Strategy**, and **Executor** tasks; the binary observes the fatal token and decides to exit.
+
+## Example dialogue
+
+> **Dev:** "When the WebSocket drops, who decides whether to reconnect?"
+> **Maintainer:** "The Collector's **Reconnect Policy**. It returns **Retry** with a backoff until the failure count crosses the threshold, then it returns **Fatal**."
+> **Dev:** "And **Fatal** kills the process?"
+> **Maintainer:** "The library never calls `exit`. **Fatal** cancels the observe-only fatal token and then the root token; the binary sees the fatal token, tells it apart from a Ctrl-C, and restarts so the orchestrator re-syncs from clean state."
+
+## Flagged ambiguities
+
+- "retry" was used for both a single backoff-and-reconnect step and the whole give-up-or-keep-trying policy — resolved: a single step is a **Retry** decision; the state machine that emits those decisions is the **Reconnect Policy**.
+- A persistent stream-*creation* failure and a persistent stream-*end* are the same concept to the Reconnect Policy: both feed one counter and both can reach **Fatal**. The earlier code treated creation-failure as a quiet task exit — that asymmetry was an accidental gap, not a decision.

--- a/README.md
+++ b/README.md
@@ -83,14 +83,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut handle = engine.run().await?;
 
-    // Run until Ctrl-C, or until a collector becomes unrecoverable.
-    tokio::select! {
-        _ = tokio::signal::ctrl_c() => {}
+    // Run until Ctrl-C, or until a collector becomes unrecoverable. Bind the
+    // outcome to the branch that actually won the `select!` — don't re-check
+    // `handle.fatal.is_cancelled()` afterwards, or a Ctrl-C that races a fatal
+    // cancellation gets mislabeled as a collector failure.
+    let fatal = tokio::select! {
+        _ = tokio::signal::ctrl_c() => false,
         _ = handle.fatal.cancelled() => {
             tracing::error!("collector unrecoverable; restarting");
+            true
         }
-    }
-    let fatal = handle.fatal.is_cancelled();
+    };
     handle.token.cancel();
     while handle.tasks.join_next().await.is_some() {}
 

--- a/README.md
+++ b/README.md
@@ -81,16 +81,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     engine.add_strategy(Box::new(my_strategy));
     engine.add_executor(Box::new(my_executor));
 
-    let (cancel_token, mut join_set) = engine.run().await?;
+    let mut handle = engine.run().await?;
 
-    // Run until Ctrl-C
-    tokio::signal::ctrl_c().await?;
-    cancel_token.cancel();
-    while join_set.join_next().await.is_some() {}
+    // Run until Ctrl-C, or until a collector becomes unrecoverable.
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {}
+        _ = handle.fatal.cancelled() => {
+            tracing::error!("collector unrecoverable; restarting");
+        }
+    }
+    let fatal = handle.fatal.is_cancelled();
+    handle.token.cancel();
+    while handle.tasks.join_next().await.is_some() {}
 
+    // The library never calls `process::exit`; the binary decides. Exiting
+    // non-zero lets an orchestrator restart the process with a fresh sync.
+    if fatal {
+        std::process::exit(1);
+    }
     Ok(())
 }
 ```
+
+On a persistent WebSocket disconnect (or a stream that can never be
+established), each collector retries with exponential backoff up to a
+configurable threshold (`Engine::with_reconnect_config`). Once exhausted, the
+engine cancels every task and fires `handle.fatal` — an observe-only token that
+lets the binary tell a fatal shutdown apart from a Ctrl-C one and restart,
+rather than the library killing the process.
 
 ## Testing
 

--- a/examples/basic_example.rs
+++ b/examples/basic_example.rs
@@ -82,13 +82,13 @@ async fn main() -> Result<()> {
     engine.add_executor(Box::new(PrintExecutor));
 
     println!("Starting engine — will process 5 ticks then exit...\n");
-    let (token, mut set) = engine.run().await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    let mut handle = engine.run().await.map_err(|e| anyhow::anyhow!("{e}"))?;
 
     // Wait for all tasks to finish (the finite collector will complete).
     tokio::time::sleep(std::time::Duration::from_secs(4)).await;
-    token.cancel();
+    handle.token.cancel();
 
-    while set.join_next().await.is_some() {}
+    while handle.tasks.join_next().await.is_some() {}
 
     println!("\nDone!");
     Ok(())

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -266,6 +266,18 @@ where
             info!("syncing strategy state...");
             tokio::select! {
                 _ = token.cancelled() => {
+                    // A collector may have escalated to `Fatal` during sync,
+                    // cancelling the root token. Hand back the handle so the
+                    // caller still observes `fatal` (already cancelled) and
+                    // follows the documented exit path. Only a caller-initiated
+                    // cancellation (fatal unset) is a plain error.
+                    if fatal.is_cancelled() {
+                        return Ok(EngineHandle {
+                            token,
+                            tasks: set,
+                            fatal,
+                        });
+                    }
                     return Err("engine cancelled during strategy sync".into());
                 }
                 result = strategy.sync_state() => {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,5 +1,6 @@
+pub mod reconnect;
+
 use std::marker::PhantomData;
-use std::time::Duration;
 
 use tokio::sync::broadcast::{self, Sender};
 use tokio::task::JoinSet;
@@ -8,6 +9,23 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::types::{Collector, Executor, Strategy};
+use reconnect::{Decision, ReconnectConfig, ReconnectPolicy};
+
+/// Handle returned by [`Engine::run`]. Bundles the cooperative-shutdown token,
+/// the set of running tasks, and an observe-only token that fires if a
+/// collector becomes unrecoverable.
+pub struct EngineHandle {
+    /// Cancel this to shut the engine down cooperatively.
+    pub token: CancellationToken,
+    /// The spawned collector/strategy/executor tasks.
+    pub tasks: JoinSet<()>,
+    /// Observe-only. The engine cancels this — and then `token` — if a collector
+    /// exhausts its [`ReconnectPolicy`], so the binary can tell a fatal shutdown
+    /// apart from a caller-initiated one. The library never calls
+    /// `process::exit`; the binary observes this and decides whether to restart.
+    /// Do not cancel it yourself.
+    pub fatal: CancellationToken,
+}
 
 /// The main engine of Artemis. This struct is responsible for orchestrating the
 /// data flow between collectors, strategies, and executors.
@@ -27,6 +45,9 @@ pub struct Engine<E, A> {
     /// The capacity of the action channel.
     action_channel_capacity: usize,
 
+    /// How collectors reconnect after a lost or failed stream.
+    reconnect_config: ReconnectConfig,
+
     _a: PhantomData<A>,
 }
 
@@ -38,6 +59,7 @@ impl<E, A> Default for Engine<E, A> {
             executors: vec![],
             event_channel_capacity: 512,
             action_channel_capacity: 512,
+            reconnect_config: ReconnectConfig::default(),
             _a: PhantomData,
         }
     }
@@ -57,6 +79,7 @@ impl<E, A> Engine<E, A> {
             executors,
             event_channel_capacity,
             action_channel_capacity,
+            reconnect_config: ReconnectConfig::default(),
             _a: PhantomData,
         }
     }
@@ -68,6 +91,12 @@ impl<E, A> Engine<E, A> {
 
     pub fn with_action_channel_capacity(mut self, capacity: usize) -> Self {
         self.action_channel_capacity = capacity;
+        self
+    }
+
+    /// Sets the [`ReconnectConfig`] applied to every collector.
+    pub fn with_reconnect_config(mut self, config: ReconnectConfig) -> Self {
+        self.reconnect_config = config;
         self
     }
 }
@@ -100,14 +129,20 @@ where
     /// buffer in the broadcast channel while historical sync runs. This
     /// eliminates the gap between HTTP replay and WS subscription.
     ///
-    /// Returns a [`CancellationToken`] that can be used to shut down the engine,
-    /// and a [`JoinSet`] that can be used to await task completion.
-    pub async fn run(self) -> Result<(CancellationToken, JoinSet<()>), Box<dyn std::error::Error>> {
+    /// Returns an [`EngineHandle`] carrying the shutdown token, the running
+    /// tasks, and a one-shot that fires if a collector becomes unrecoverable.
+    pub async fn run(self) -> Result<EngineHandle, Box<dyn std::error::Error>> {
         let (event_sender, _): (Sender<E>, _) = broadcast::channel(self.event_channel_capacity);
         let (action_sender, _): (Sender<A>, _) = broadcast::channel(self.action_channel_capacity);
 
         let token = CancellationToken::new();
         let mut set = JoinSet::new();
+
+        let reconnect_config = self.reconnect_config;
+        // Independent of `token` so a caller-initiated shutdown isn't mistaken
+        // for a fatal one. Clone + idempotent, so every collector shares it
+        // directly — first to escalate wins, the rest are no-ops.
+        let fatal = CancellationToken::new();
 
         // Spawn executors first (they subscribe before any events flow).
         for mut executor in self.executors {
@@ -143,30 +178,44 @@ where
         }
 
         // Spawn collectors so WS subscriptions are active during strategy sync.
+        //
+        // Each collector drives a per-collector `ReconnectPolicy`: it pumps
+        // events while the stream lives, and on a lost or failed stream asks the
+        // policy whether to retry-after-backoff or escalate. A `Fatal` verdict
+        // cancels the `fatal` token (the reason) and the *root* token (tearing
+        // down every task) — the library never calls `process::exit`.
         for collector in self.collectors {
             let event_sender = event_sender.clone();
             let child = token.child_token();
+            let root = token.clone();
+            let fatal = fatal.clone();
             set.spawn(async move {
                 info!("starting collector...");
-                let mut retries = 0u32;
+                let mut policy = ReconnectPolicy::new(reconnect_config);
                 loop {
                     let mut event_stream = match collector.get_event_stream().await {
                         Ok(s) => s,
                         Err(e) => {
-                            retries += 1;
-                            error!("collector stream creation failed (attempt {retries}): {e}");
-                            if retries >= 3 {
-                                error!("collector failed {retries} times, giving up");
-                                return;
+                            error!("collector stream creation failed: {e}");
+                            match policy.on_creation_failed() {
+                                Decision::Retry { after } => {
+                                    warn!("retrying stream creation in {after:?}");
+                                    tokio::select! {
+                                        _ = child.cancelled() => return,
+                                        _ = tokio::time::sleep(after) => continue,
+                                    }
+                                }
+                                Decision::Fatal => {
+                                    error!(
+                                        "collector unrecoverable (creation), shutting down engine"
+                                    );
+                                    fatal.cancel();
+                                    root.cancel();
+                                    return;
+                                }
                             }
-                            tokio::select! {
-                                _ = child.cancelled() => return,
-                                _ = tokio::time::sleep(Duration::from_secs(2u64.pow(retries))) => {}
-                            }
-                            continue;
                         }
                     };
-                    let mut received_events = false;
                     loop {
                         tokio::select! {
                             _ = child.cancelled() => {
@@ -176,7 +225,7 @@ where
                             event = event_stream.next() => {
                                 match event {
                                     Some(event) => {
-                                        received_events = true;
+                                        policy.on_events_received();
                                         if let Err(e) = event_sender.send(event) {
                                             error!("error sending event: {e}");
                                         }
@@ -186,19 +235,21 @@ where
                             }
                         }
                     }
-                    // Stream ended (WS disconnected)
-                    if received_events {
-                        retries = 0;
-                    }
-                    retries += 1;
-                    warn!("collector stream ended (attempt {retries}), retrying...");
-                    if retries >= 3 {
-                        error!("collector stream ended {retries} times, exiting process");
-                        std::process::exit(1);
-                    }
-                    tokio::select! {
-                        _ = child.cancelled() => return,
-                        _ = tokio::time::sleep(Duration::from_secs(2u64.pow(retries))) => {}
+                    // Stream ended (e.g. the WebSocket dropped).
+                    match policy.on_stream_ended() {
+                        Decision::Retry { after } => {
+                            warn!("collector stream ended, retrying in {after:?}");
+                            tokio::select! {
+                                _ = child.cancelled() => return,
+                                _ = tokio::time::sleep(after) => {}
+                            }
+                        }
+                        Decision::Fatal => {
+                            error!("collector unrecoverable (stream ended), shutting down engine");
+                            fatal.cancel();
+                            root.cancel();
+                            return;
+                        }
                     }
                 }
             });
@@ -271,6 +322,10 @@ where
             });
         }
 
-        Ok((token, set))
+        Ok(EngineHandle {
+            token,
+            tasks: set,
+            fatal,
+        })
     }
 }

--- a/src/engine/reconnect.rs
+++ b/src/engine/reconnect.rs
@@ -1,0 +1,184 @@
+//! The reconnect policy for a [collector](crate::types::Collector).
+//!
+//! When a collector's event stream is lost (the subscription ends) or can never
+//! be established (stream creation fails), the engine consults a per-collector
+//! [`ReconnectPolicy`] to decide whether to [`Retry`](Decision::Retry) after a
+//! backoff or to declare the collector [`Fatal`](Decision::Fatal).
+//!
+//! The policy is a pure state machine: it owns the consecutive-failure counter
+//! and the backoff curve, performs no I/O, and keeps no clock. The driver
+//! supplies the actual sleeping and cancellation. This is what makes the
+//! escalation behaviour testable without a process actually dying.
+
+use std::time::Duration;
+
+/// Configuration for a [`ReconnectPolicy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReconnectConfig {
+    /// Number of consecutive failures (stream creation *or* stream end) that
+    /// escalates a collector to [`Fatal`](Decision::Fatal).
+    pub max_failures: u32,
+    /// Base unit for the exponential backoff. The delay before the Nth retry is
+    /// `base_delay * 2^N`.
+    pub base_delay: Duration,
+}
+
+impl Default for ReconnectConfig {
+    /// The historical defaults: escalate on the 3rd consecutive failure, with a
+    /// backoff of 2s, 4s before that.
+    fn default() -> Self {
+        Self {
+            max_failures: 3,
+            base_delay: Duration::from_secs(1),
+        }
+    }
+}
+
+/// What the engine should do after a collector's stream is lost or fails to open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    /// Recreate the stream after waiting `after`.
+    Retry { after: Duration },
+    /// The collector is unrecoverable. The engine tears down all tasks and
+    /// surfaces a fatal cause so the binary can restart with a fresh sync.
+    Fatal,
+}
+
+/// Per-collector reconnect state machine. See the [module docs](self).
+#[derive(Debug)]
+pub struct ReconnectPolicy {
+    config: ReconnectConfig,
+    /// Consecutive failures since the last delivered event.
+    failures: u32,
+}
+
+impl ReconnectPolicy {
+    /// Creates a policy with the given configuration.
+    pub fn new(config: ReconnectConfig) -> Self {
+        Self {
+            config,
+            failures: 0,
+        }
+    }
+
+    /// Records that the collector delivered a real event. This is the *only*
+    /// thing that resets the failure counter: a stream that connects but never
+    /// delivers must still march toward [`Fatal`](Decision::Fatal), so an
+    /// orchestrator restarts the process rather than leaving a silent zombie.
+    pub fn on_events_received(&mut self) {
+        self.failures = 0;
+    }
+
+    /// Records that stream creation failed, and returns the engine's next move.
+    pub fn on_creation_failed(&mut self) -> Decision {
+        self.record_failure()
+    }
+
+    /// Records that the stream ended (e.g. the WebSocket dropped), and returns
+    /// the engine's next move.
+    pub fn on_stream_ended(&mut self) -> Decision {
+        self.record_failure()
+    }
+
+    /// Stream creation and stream end feed one counter and share one escalation:
+    /// a collector that can never open its stream is just as much a zombie as
+    /// one whose stream keeps dropping.
+    fn record_failure(&mut self) -> Decision {
+        self.failures += 1;
+        if self.failures >= self.config.max_failures {
+            Decision::Fatal
+        } else {
+            Decision::Retry {
+                after: self.backoff(),
+            }
+        }
+    }
+
+    /// `base_delay * 2^failures`, saturating rather than overflowing for large
+    /// failure counts.
+    fn backoff(&self) -> Duration {
+        let factor = 2u32.checked_pow(self.failures).unwrap_or(u32::MAX);
+        self.config.base_delay.saturating_mul(factor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn policy(max_failures: u32) -> ReconnectPolicy {
+        ReconnectPolicy::new(ReconnectConfig {
+            max_failures,
+            base_delay: Duration::from_secs(1),
+        })
+    }
+
+    #[test]
+    fn backoff_doubles_until_threshold() {
+        let mut p = policy(4);
+        assert_eq!(
+            p.on_stream_ended(),
+            Decision::Retry {
+                after: Duration::from_secs(2)
+            }
+        );
+        assert_eq!(
+            p.on_stream_ended(),
+            Decision::Retry {
+                after: Duration::from_secs(4)
+            }
+        );
+        assert_eq!(
+            p.on_stream_ended(),
+            Decision::Retry {
+                after: Duration::from_secs(8)
+            }
+        );
+        assert_eq!(p.on_stream_ended(), Decision::Fatal);
+    }
+
+    #[test]
+    fn creation_failure_escalates_to_fatal() {
+        let mut p = policy(2);
+        assert!(matches!(p.on_creation_failed(), Decision::Retry { .. }));
+        assert_eq!(p.on_creation_failed(), Decision::Fatal);
+    }
+
+    #[test]
+    fn stream_end_escalates_to_fatal() {
+        let mut p = policy(2);
+        assert!(matches!(p.on_stream_ended(), Decision::Retry { .. }));
+        assert_eq!(p.on_stream_ended(), Decision::Fatal);
+    }
+
+    #[test]
+    fn creation_and_end_share_one_counter() {
+        let mut p = policy(3);
+        assert!(matches!(p.on_creation_failed(), Decision::Retry { .. }));
+        assert!(matches!(p.on_stream_ended(), Decision::Retry { .. }));
+        // Third consecutive failure, regardless of kind, is fatal.
+        assert_eq!(p.on_creation_failed(), Decision::Fatal);
+    }
+
+    #[test]
+    fn delivered_events_reset_the_counter() {
+        let mut p = policy(3);
+        assert!(matches!(p.on_stream_ended(), Decision::Retry { .. }));
+        assert!(matches!(p.on_stream_ended(), Decision::Retry { .. }));
+        p.on_events_received();
+        // Counter is back to zero; we get two retries again before fatal.
+        assert!(matches!(p.on_stream_ended(), Decision::Retry { .. }));
+        assert!(matches!(p.on_stream_ended(), Decision::Retry { .. }));
+        assert_eq!(p.on_stream_ended(), Decision::Fatal);
+    }
+
+    #[test]
+    fn flapping_without_events_still_reaches_fatal() {
+        // Connect, deliver nothing, disconnect — repeatedly. Without a real
+        // event the counter never resets, so it must escalate.
+        let mut p = policy(3);
+        assert!(matches!(p.on_stream_ended(), Decision::Retry { .. }));
+        assert!(matches!(p.on_stream_ended(), Decision::Retry { .. }));
+        assert_eq!(p.on_stream_ended(), Decision::Fatal);
+    }
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -615,4 +615,62 @@ mod engine_tests {
 
         while handle.tasks.join_next().await.is_some() {}
     }
+
+    /// A collector that escalates to `Fatal` *while* a strategy is still
+    /// syncing. The root-token cancellation must not be reported as a generic
+    /// `Err` — `run` must hand back an `EngineHandle` with `fatal` set so the
+    /// caller still observes the fatal cause and follows the documented exit
+    /// path. Regression test for the fatal-during-sync handle loss.
+    #[tokio::test]
+    async fn test_engine_fatal_during_sync_returns_handle() {
+        use artemis_light::engine::reconnect::ReconnectConfig;
+        use std::time::Duration;
+
+        /// Always yields an empty stream — the subscription ends at once.
+        struct EndingCollector;
+
+        #[async_trait]
+        impl Collector<u32> for EndingCollector {
+            async fn get_event_stream(&self) -> Result<CollectorStream<'_, u32>> {
+                Ok(Box::pin(futures::stream::empty::<u32>()))
+            }
+        }
+
+        /// Strategy whose sync outlives the collector's escalation window.
+        struct SlowSyncStrategy;
+
+        #[async_trait]
+        impl Strategy<u32, u32> for SlowSyncStrategy {
+            async fn sync_state(&mut self) -> Result<()> {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                Ok(())
+            }
+            async fn process_event(&mut self, event: u32) -> Result<ActionStream<'_, u32>> {
+                Ok(Box::pin(futures::stream::iter(vec![event])))
+            }
+        }
+
+        let mut engine = Engine::<u32, u32>::default().with_reconnect_config(ReconnectConfig {
+            max_failures: 2,
+            base_delay: Duration::from_millis(10),
+        });
+        engine.add_collector(Box::new(EndingCollector));
+        engine.add_strategy(Box::new(SlowSyncStrategy));
+
+        let mut handle = tokio::time::timeout(Duration::from_secs(1), engine.run())
+            .await
+            .expect("run did not return within 1 s")
+            .expect("fatal during sync should return Ok(handle), not Err");
+
+        assert!(
+            handle.fatal.is_cancelled(),
+            "fatal cause should be observable on the returned handle"
+        );
+        assert!(
+            handle.token.is_cancelled(),
+            "root token should be cancelled on fatal escalation"
+        );
+
+        while handle.tasks.join_next().await.is_some() {}
+    }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -442,13 +442,13 @@ mod engine_tests {
             count: count.clone(),
         }));
 
-        let (token, mut set) = engine.run().await.unwrap();
+        let mut handle = engine.run().await.unwrap();
 
         // The finite collector will complete; give it a moment to drain.
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        token.cancel();
+        handle.token.cancel();
 
-        while set.join_next().await.is_some() {}
+        while handle.tasks.join_next().await.is_some() {}
 
         assert_eq!(count.load(Ordering::SeqCst), 3);
     }
@@ -465,7 +465,7 @@ mod engine_tests {
             count: count.clone(),
         }));
 
-        let (token, mut set) = engine.run().await.unwrap();
+        let mut handle = engine.run().await.unwrap();
 
         // Let it run briefly so some events flow.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -474,10 +474,10 @@ mod engine_tests {
             "expected some events to flow"
         );
 
-        token.cancel();
+        handle.token.cancel();
 
         let deadline = tokio::time::timeout(std::time::Duration::from_secs(2), async {
-            while set.join_next().await.is_some() {}
+            while handle.tasks.join_next().await.is_some() {}
         })
         .await;
 
@@ -528,13 +528,13 @@ mod engine_tests {
             count: count.clone(),
         }));
 
-        let (token, mut set) = engine.run().await.unwrap();
+        let mut handle = engine.run().await.unwrap();
 
         // Give enough time for events to drain through the slow strategy.
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-        token.cancel();
+        handle.token.cancel();
 
-        while set.join_next().await.is_some() {}
+        while handle.tasks.join_next().await.is_some() {}
 
         let executed = count.load(Ordering::SeqCst);
         assert!(
@@ -556,17 +556,63 @@ mod engine_tests {
             count: count.clone(),
         }));
 
-        let (token, mut set) = engine.run().await.unwrap();
+        let mut handle = engine.run().await.unwrap();
 
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        token.cancel();
+        handle.token.cancel();
 
-        while set.join_next().await.is_some() {}
+        while handle.tasks.join_next().await.is_some() {}
 
         assert_eq!(
             count.load(Ordering::SeqCst),
             2,
             "good collector's events should still flow"
         );
+    }
+
+    /// A collector whose stream always ends immediately + a low failure
+    /// threshold; verify the engine surfaces a fatal cause and cancels its own
+    /// token — exercising the C1 escalation *without the test process dying*.
+    #[tokio::test]
+    async fn test_engine_collector_fatal_escalation() {
+        use artemis_light::engine::reconnect::ReconnectConfig;
+        use std::time::Duration;
+
+        /// Always yields an empty stream — i.e. the subscription ends at once.
+        struct EndingCollector;
+
+        #[async_trait]
+        impl Collector<u32> for EndingCollector {
+            async fn get_event_stream(&self) -> Result<CollectorStream<'_, u32>> {
+                Ok(Box::pin(futures::stream::empty::<u32>()))
+            }
+        }
+
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let mut engine = Engine::<u32, u32>::default().with_reconnect_config(ReconnectConfig {
+            max_failures: 2,
+            base_delay: Duration::from_millis(10),
+        });
+        engine.add_collector(Box::new(EndingCollector));
+        engine.add_strategy(Box::new(EchoStrategy));
+        engine.add_executor(Box::new(CountingExecutor {
+            count: count.clone(),
+        }));
+
+        let mut handle = engine.run().await.unwrap();
+
+        // The fatal token fires after the threshold of consecutive stream-ends.
+        tokio::time::timeout(Duration::from_secs(1), handle.fatal.cancelled())
+            .await
+            .expect("fatal signal did not fire within 1 s");
+
+        // The engine also cancelled its root token; the process is still alive.
+        assert!(
+            handle.token.is_cancelled(),
+            "root token should be cancelled on fatal escalation"
+        );
+
+        while handle.tasks.join_next().await.is_some() {}
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking change to Engine::run’s return type and shutdown semantics; mis-handling handle.fatal vs Ctrl-C can mislabel restarts, though behavior is documented and covered by new tests.
> 
> **Overview**
> Collector reconnect and fatal shutdown are refactored into a testable **`ReconnectPolicy`** (`Retry` with exponential backoff vs **`Fatal`**), wired through **`Engine::with_reconnect_config`** instead of ad hoc retries in the engine loop.
> 
> **`Engine::run`** now returns an **`EngineHandle`** (`token`, `tasks`, observe-only **`fatal`**) rather than a bare cancellation token and `JoinSet`. On exhaustion, the engine cancels **`fatal`** then the root token and tears down tasks; the library no longer calls **`process::exit`** (stream-end fatals used to). Stream **creation** failures share the same failure counter and escalation path as stream **ends**, fixing the prior quiet exit on create failure. If a collector goes fatal **during strategy sync**, **`run`** returns **`Ok(handle)`** with **`fatal`** already set instead of a generic cancel error.
> 
> **`CONTEXT.md`** documents domain terms; README, examples, and tests are updated for the new handle and fatal-observation pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b0088659d80a86b5fc9d12d21e46114cce1a0be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->