### PR TITLE
refactor: extract Collector Driver and broadcast-to-Stream adapter

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,8 +18,12 @@ The sink that carries out actions in an external domain (submitting a tx, postin
 The orchestrator that spawns every Collector, Strategy, and Executor as a task and fans events/actions between them over broadcast channels.
 
 **Reconnect Policy**:
-The per-Collector state machine that decides, after a stream is lost or never established, whether to **Retry** (after a backoff delay) or declare the Collector **Fatal** (unrecoverable). It owns the consecutive-failure counter and the backoff curve; it performs no I/O and keeps no clock — the driver supplies timing and cancellation.
+The per-Collector state machine that decides, after a stream is lost or never established, whether to **Retry** (after a backoff delay) or declare the Collector **Fatal** (unrecoverable). It owns the consecutive-failure counter and the backoff curve; it performs no I/O and keeps no clock — the **Collector Driver** supplies timing and cancellation.
 _Avoid_: retry handler, supervisor, backoff helper
+
+**Collector Driver**:
+The loop that runs one Collector's full lifecycle: subscribe to the event stream, pump its events into the event channel, and on a lost or failed stream consult the Collector's **Reconnect Policy** — sleeping for a **Retry** or, on a **Fatal** verdict, cancelling the fatal token and then the root token. It supplies the I/O the policy refuses to: the actual `sleep`, the actual stream subscription, the actual send. The Engine spawns one Driver per Collector and otherwise stays out of reconnection.
+_Avoid_: supervisor, collector task, reconnect loop
 
 **Fatal**:
 The Reconnect Policy's verdict that a Collector cannot recover. The Engine responds by cancelling a dedicated, observe-only **fatal token** (the reason) and then the root token (tearing down every task), so the binary can tell a fatal shutdown apart from a caller-initiated one and restart the process with a fresh sync — never by killing the host process itself.
@@ -27,8 +31,8 @@ _Avoid_: crash, panic, die
 
 ## Relationships
 
-- An **Engine** drives many **Collectors**; each **Collector** task owns one **Reconnect Policy** instance.
-- A **Reconnect Policy** counts consecutive stream failures and resets that count only when its Collector delivers a real event.
+- An **Engine** spawns one **Collector Driver** per **Collector**; each Driver owns one **Reconnect Policy** instance.
+- A **Reconnect Policy** counts consecutive stream failures and resets that count only when its **Collector Driver** reports a delivered event.
 - A **Fatal** verdict cancels the observe-only fatal token, then the root token shared by all **Collector**, **Strategy**, and **Executor** tasks; the binary observes the fatal token and decides to exit.
 
 ## Example dialogue

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ async-stream = "0.3"
 anyhow = "1.0.97"
 tracing = "0.1.41"
 
+[dev-dependencies]
+## `test-util` enables `tokio::time::pause`/`start_paused` so the collector
+## driver's backoff timing can be asserted on virtual time.
+tokio = { version = "1.44", features = ["full", "test-util"] }
+
 [[example]]
 name = "basic_example"
 path = "examples/basic_example.rs"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,15 +1,17 @@
+mod channel;
+mod driver;
 pub mod reconnect;
 
 use std::marker::PhantomData;
 
+use futures::StreamExt;
 use tokio::sync::broadcast::{self, Sender};
 use tokio::task::JoinSet;
-use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 use crate::types::{Collector, Executor, Strategy};
-use reconnect::{Decision, ReconnectConfig, ReconnectPolicy};
+use reconnect::ReconnectConfig;
 
 /// Handle returned by [`Engine::run`]. Bundles the cooperative-shutdown token,
 /// the set of running tasks, and an observe-only token that fires if a
@@ -144,34 +146,20 @@ where
         // directly — first to escalate wins, the rest are no-ops.
         let fatal = CancellationToken::new();
 
-        // Spawn executors first (they subscribe before any events flow).
+        // Spawn executors first (they subscribe before any events flow). The
+        // action channel — with lag logged, closure and cancellation folded in —
+        // is presented as a plain stream, so the loop is just the per-action work.
         for mut executor in self.executors {
-            let mut receiver = action_sender.subscribe();
-            let child = token.child_token();
+            let mut actions = Box::pin(channel::into_stream(
+                action_sender.subscribe(),
+                token.child_token(),
+                "executor",
+            ));
             set.spawn(async move {
                 info!("starting executor... ");
-                loop {
-                    tokio::select! {
-                        _ = child.cancelled() => {
-                            info!("executor shutting down");
-                            break;
-                        }
-                        result = receiver.recv() => {
-                            match result {
-                                Ok(action) => {
-                                    if let Err(e) = executor.execute(action).await {
-                                        error!("error executing action: {}", e);
-                                    }
-                                }
-                                Err(broadcast::error::RecvError::Lagged(n)) => {
-                                    warn!("executor receiver lagged, skipped {n} messages");
-                                }
-                                Err(broadcast::error::RecvError::Closed) => {
-                                    info!("action channel closed, executor shutting down");
-                                    break;
-                                }
-                            }
-                        }
+                while let Some(action) = actions.next().await {
+                    if let Err(e) = executor.execute(action).await {
+                        error!("error executing action: {e}");
                     }
                 }
             });
@@ -179,87 +167,31 @@ where
 
         // Spawn collectors so WS subscriptions are active during strategy sync.
         //
-        // Each collector drives a per-collector `ReconnectPolicy`: it pumps
-        // events while the stream lives, and on a lost or failed stream asks the
-        // policy whether to retry-after-backoff or escalate. A `Fatal` verdict
-        // cancels the `fatal` token (the reason) and the *root* token (tearing
-        // down every task) — the library never calls `process::exit`.
+        // Each collector is handed to a [`Collector Driver`](driver), which owns
+        // its full lifecycle — subscribe, pump events, and on a lost or failed
+        // stream consult the per-collector `ReconnectPolicy` to retry-after-
+        // backoff or escalate. A `Fatal` verdict cancels the `fatal` token (the
+        // reason) and the *root* token (tearing down every task); the library
+        // never calls `process::exit`.
         for collector in self.collectors {
-            let event_sender = event_sender.clone();
-            let child = token.child_token();
-            let root = token.clone();
-            let fatal = fatal.clone();
-            set.spawn(async move {
-                info!("starting collector...");
-                let mut policy = ReconnectPolicy::new(reconnect_config);
-                loop {
-                    let mut event_stream = match collector.subscribe().await {
-                        Ok(s) => s,
-                        Err(e) => {
-                            error!("collector stream creation failed: {e}");
-                            match policy.on_creation_failed() {
-                                Decision::Retry { after } => {
-                                    warn!("retrying stream creation in {after:?}");
-                                    tokio::select! {
-                                        _ = child.cancelled() => return,
-                                        _ = tokio::time::sleep(after) => continue,
-                                    }
-                                }
-                                Decision::Fatal => {
-                                    error!(
-                                        "collector unrecoverable (creation), shutting down engine"
-                                    );
-                                    fatal.cancel();
-                                    root.cancel();
-                                    return;
-                                }
-                            }
-                        }
-                    };
-                    loop {
-                        tokio::select! {
-                            _ = child.cancelled() => {
-                                info!("collector shutting down");
-                                return;
-                            }
-                            event = event_stream.next() => {
-                                match event {
-                                    Some(event) => {
-                                        policy.on_events_received();
-                                        if let Err(e) = event_sender.send(event) {
-                                            error!("error sending event: {e}");
-                                        }
-                                    }
-                                    None => break,
-                                }
-                            }
-                        }
-                    }
-                    // Stream ended (e.g. the WebSocket dropped).
-                    match policy.on_stream_ended() {
-                        Decision::Retry { after } => {
-                            warn!("collector stream ended, retrying in {after:?}");
-                            tokio::select! {
-                                _ = child.cancelled() => return,
-                                _ = tokio::time::sleep(after) => {}
-                            }
-                        }
-                        Decision::Fatal => {
-                            error!("collector unrecoverable (stream ended), shutting down engine");
-                            fatal.cancel();
-                            root.cancel();
-                            return;
-                        }
-                    }
-                }
-            });
+            let tokens = driver::CollectorTokens {
+                child: token.child_token(),
+                fatal: fatal.clone(),
+                root: token.clone(),
+            };
+            set.spawn(driver::run(
+                collector,
+                reconnect_config,
+                event_sender.clone(),
+                tokens,
+            ));
         }
 
         // Subscribe each strategy to the event channel before syncing so that
         // events produced by collectors during sync are buffered in the receiver.
         // Cancellation is respected during sync via the token.
         for mut strategy in self.strategies {
-            let mut event_receiver = event_sender.subscribe();
+            let event_receiver = event_sender.subscribe();
             let action_sender = action_sender.clone();
             let child = token.child_token();
 
@@ -287,48 +219,27 @@ where
 
             set.spawn(async move {
                 info!("starting strategy... ");
-                loop {
-                    tokio::select! {
-                        _ = child.cancelled() => {
-                            info!("strategy shutting down");
-                            break;
-                        }
-                        result = event_receiver.recv() => {
-                            match result {
-                                Ok(event) => {
-                                    match strategy.process_event(event).await {
-                                        Ok(mut action_stream) => {
-                                            loop {
-                                                tokio::select! {
-                                                    _ = child.cancelled() => {
-                                                        info!("strategy shutting down while draining action stream");
-                                                        return;
-                                                    }
-                                                    action = action_stream.next() => {
-                                                        match action {
-                                                            Some(action) => {
-                                                                if let Err(e) = action_sender.send(action) {
-                                                                    error!("error sending action: {}", e);
-                                                                }
-                                                            }
-                                                            None => break,
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        Err(e) => error!("error processing event: {}", e),
-                                    }
-                                }
-                                Err(broadcast::error::RecvError::Lagged(n)) => {
-                                    warn!("strategy receiver lagged, skipped {n} messages");
-                                }
-                                Err(broadcast::error::RecvError::Closed) => {
-                                    info!("event channel closed, strategy shutting down");
-                                    break;
+                let mut events = Box::pin(channel::into_stream(
+                    event_receiver,
+                    child.clone(),
+                    "strategy",
+                ));
+                while let Some(event) = events.next().await {
+                    match strategy.process_event(event).await {
+                        Ok(action_stream) => {
+                            // Drain the actions, but stop mid-stream on shutdown
+                            // rather than finishing a long stream first. Pinned on
+                            // the stack so the per-event drain costs no allocation.
+                            let mut actions = std::pin::pin!(
+                                action_stream.take_until(child.clone().cancelled_owned())
+                            );
+                            while let Some(action) = actions.next().await {
+                                if let Err(e) = action_sender.send(action) {
+                                    error!("error sending action: {e}");
                                 }
                             }
                         }
+                        Err(e) => error!("error processing event: {e}"),
                     }
                 }
             });

--- a/src/engine/channel.rs
+++ b/src/engine/channel.rs
@@ -1,0 +1,103 @@
+//! Adapts a [`broadcast::Receiver`] into a cancellation-aware, lag-logging
+//! [`Stream`].
+//!
+//! The engine fans events to strategies and actions to executors over
+//! [`broadcast`] channels. Each consumer's loop has to handle the same three
+//! concerns: a [`Lagged`](tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged)
+//! receiver (log and skip), a closed channel (stop), and cooperative shutdown
+//! (stop). [`into_stream`] folds all three into one `Stream` so a consumer can
+//! just `while let Some(item) = stream.next().await { … }`.
+
+use futures::StreamExt;
+use tokio::sync::broadcast;
+use tokio_stream::Stream;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+/// Wraps `receiver` as a `Stream` that logs and skips lag, ends when the
+/// channel closes, and ends when `cancel` fires. `label` tags the log lines.
+pub(crate) fn into_stream<T>(
+    receiver: broadcast::Receiver<T>,
+    cancel: CancellationToken,
+    label: &'static str,
+) -> impl Stream<Item = T>
+where
+    T: Clone + Send + 'static,
+{
+    BroadcastStream::new(receiver)
+        .filter_map(move |result| async move {
+            match result {
+                Ok(item) => Some(item),
+                Err(BroadcastStreamRecvError::Lagged(n)) => {
+                    warn!("{label} receiver lagged, skipped {n} messages");
+                    None
+                }
+            }
+        })
+        .take_until(async move {
+            cancel.cancelled().await;
+            info!("{label} shutting down");
+        })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tokio_stream::StreamExt;
+
+    #[tokio::test]
+    async fn yields_sent_items() {
+        let (tx, rx) = broadcast::channel::<u32>(16);
+        let mut stream = Box::pin(into_stream(rx, CancellationToken::new(), "test"));
+
+        tx.send(1).unwrap();
+        tx.send(2).unwrap();
+
+        assert_eq!(stream.next().await, Some(1));
+        assert_eq!(stream.next().await, Some(2));
+    }
+
+    #[tokio::test]
+    async fn skips_lag_and_keeps_flowing() {
+        // Capacity 2, four sends without consuming: the receiver lags by 2.
+        let (tx, rx) = broadcast::channel::<u32>(2);
+        let mut stream = Box::pin(into_stream(rx, CancellationToken::new(), "test"));
+        for i in 1..=4 {
+            tx.send(i).unwrap();
+        }
+
+        // The lag is swallowed (not surfaced as an item or an end); the
+        // surviving items still flow through.
+        assert_eq!(stream.next().await, Some(3));
+        assert_eq!(stream.next().await, Some(4));
+    }
+
+    #[tokio::test]
+    async fn ends_when_channel_closes() {
+        let (tx, rx) = broadcast::channel::<u32>(16);
+        let mut stream = Box::pin(into_stream(rx, CancellationToken::new(), "test"));
+
+        tx.send(1).unwrap();
+        drop(tx);
+
+        assert_eq!(stream.next().await, Some(1));
+        assert_eq!(stream.next().await, None);
+    }
+
+    #[tokio::test]
+    async fn ends_when_cancelled_even_with_an_open_channel() {
+        let (tx, rx) = broadcast::channel::<u32>(16);
+        let cancel = CancellationToken::new();
+        let mut stream = Box::pin(into_stream(rx, cancel.clone(), "test"));
+
+        tx.send(1).unwrap();
+        assert_eq!(stream.next().await, Some(1));
+
+        cancel.cancel();
+        assert_eq!(stream.next().await, None, "cancellation ends the stream");
+
+        drop(tx); // keep the channel alive until after the assertion
+    }
+}

--- a/src/engine/driver.rs
+++ b/src/engine/driver.rs
@@ -1,0 +1,285 @@
+//! The [Collector Driver]: the loop that runs one
+//! [`Collector`](crate::types::Collector)'s full lifecycle.
+//!
+//! The driver subscribes to the collector's event stream, pumps its events into
+//! the engine's broadcast channel, and — on a lost or failed stream — consults
+//! the collector's [`ReconnectPolicy`] to decide whether to sleep for a
+//! [`Retry`](Decision::Retry) or, on a [`Fatal`](Decision::Fatal) verdict,
+//! cancel the fatal token and then the root token (tearing down every task).
+//!
+//! The policy refuses all I/O and keeps no clock; the driver supplies it: the
+//! actual `subscribe`, the actual `sleep`, the actual `send`. The engine spawns
+//! one driver per collector and otherwise stays out of reconnection.
+
+use tokio::sync::broadcast;
+use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+use crate::types::Collector;
+
+use super::reconnect::{Decision, ReconnectConfig, ReconnectPolicy};
+
+/// The cancellation tokens a [`run`] driver observes and owns.
+pub(crate) struct CollectorTokens {
+    /// The driver's own shutdown signal (a child of `root`). Observed while
+    /// sleeping for a retry and while pumping the stream.
+    pub child: CancellationToken,
+    /// Observe-only fatal cause. Cancelled — before `root` — when the policy
+    /// declares the collector unrecoverable, so the binary can tell a fatal
+    /// shutdown apart from a caller-initiated one.
+    pub fatal: CancellationToken,
+    /// The root token shared by every task. Cancelled after `fatal` on a fatal
+    /// escalation, tearing the whole engine down.
+    pub root: CancellationToken,
+}
+
+/// Runs one collector's full lifecycle until it is cancelled or escalates to
+/// [`Fatal`](super::reconnect::Decision::Fatal). See the [module docs](self).
+pub(crate) async fn run<E>(
+    collector: Box<dyn Collector<E>>,
+    config: ReconnectConfig,
+    events: broadcast::Sender<E>,
+    tokens: CollectorTokens,
+) where
+    E: Clone + Send + 'static,
+{
+    info!("starting collector...");
+    let CollectorTokens { child, fatal, root } = tokens;
+
+    // The Fatal escalation: cancel the observe-only fatal cause first, then the
+    // root token that tears down every task. Kept in one place so the two-step
+    // ordering can't drift between the creation-failure and stream-end sites.
+    let escalate = || {
+        fatal.cancel();
+        root.cancel();
+    };
+
+    let mut policy = ReconnectPolicy::new(config);
+    loop {
+        let mut stream = match collector.subscribe().await {
+            Ok(s) => s,
+            Err(e) => {
+                error!("collector stream creation failed: {e}");
+                match policy.on_creation_failed() {
+                    Decision::Retry { after } => {
+                        warn!("retrying stream creation in {after:?}");
+                        tokio::select! {
+                            _ = child.cancelled() => return,
+                            _ = tokio::time::sleep(after) => continue,
+                        }
+                    }
+                    Decision::Fatal => {
+                        error!("collector unrecoverable (creation), shutting down engine");
+                        escalate();
+                        return;
+                    }
+                }
+            }
+        };
+
+        loop {
+            tokio::select! {
+                _ = child.cancelled() => {
+                    info!("collector shutting down");
+                    return;
+                }
+                event = stream.next() => {
+                    match event {
+                        Some(event) => {
+                            policy.on_events_received();
+                            if let Err(e) = events.send(event) {
+                                error!("error sending event: {e}");
+                            }
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+
+        // Stream ended (e.g. the WebSocket dropped).
+        match policy.on_stream_ended() {
+            Decision::Retry { after } => {
+                warn!("collector stream ended, retrying in {after:?}");
+                tokio::select! {
+                    _ = child.cancelled() => return,
+                    _ = tokio::time::sleep(after) => {}
+                }
+            }
+            Decision::Fatal => {
+                error!("collector unrecoverable (stream ended), shutting down engine");
+                escalate();
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::types::CollectorStream;
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use std::time::Duration;
+
+    /// A collector that emits a fixed list of u32 events, then ends its stream.
+    struct FixedThenEnd {
+        items: Vec<u32>,
+    }
+
+    #[async_trait]
+    impl Collector<u32> for FixedThenEnd {
+        async fn subscribe(&self) -> Result<CollectorStream<'_, u32>> {
+            Ok(Box::pin(futures::stream::iter(self.items.clone())))
+        }
+    }
+
+    /// Builds a fresh `child`-of-`root` token set, returning handles to `fatal`
+    /// and `root` so a test can observe escalation and drive shutdown.
+    fn tokens() -> (CollectorTokens, CancellationToken, CancellationToken) {
+        let root = CancellationToken::new();
+        let child = root.child_token();
+        let fatal = CancellationToken::new();
+        (
+            CollectorTokens {
+                child,
+                fatal: fatal.clone(),
+                root: root.clone(),
+            },
+            fatal,
+            root,
+        )
+    }
+
+    fn config(max_failures: u32) -> ReconnectConfig {
+        ReconnectConfig {
+            max_failures,
+            base_delay: Duration::from_millis(1),
+        }
+    }
+
+    /// A collector whose stream always ends immediately (never delivers).
+    struct EndingCollector;
+
+    #[async_trait]
+    impl Collector<u32> for EndingCollector {
+        async fn subscribe(&self) -> Result<CollectorStream<'_, u32>> {
+            Ok(Box::pin(futures::stream::empty::<u32>()))
+        }
+    }
+
+    #[tokio::test]
+    async fn pumps_events_into_the_sender() {
+        let (tx, mut rx) = broadcast::channel::<u32>(16);
+        let (toks, _fatal, root) = tokens();
+        let collector = Box::new(FixedThenEnd {
+            items: vec![1, 2, 3],
+        });
+
+        let handle = tokio::spawn(run(collector, config(100), tx, toks));
+
+        assert_eq!(rx.recv().await.unwrap(), 1);
+        assert_eq!(rx.recv().await.unwrap(), 2);
+        assert_eq!(rx.recv().await.unwrap(), 3);
+
+        root.cancel();
+        handle.await.unwrap();
+    }
+
+    /// A collector that never delivers must march to Fatal after the threshold
+    /// of consecutive stream-ends, cancelling `fatal` *and* `root`.
+    #[tokio::test(start_paused = true)]
+    async fn empty_stream_escalates_to_fatal_and_cancels_both_tokens() {
+        let (tx, _rx) = broadcast::channel::<u32>(16);
+        let (toks, fatal, root) = tokens();
+
+        run(Box::new(EndingCollector), config(2), tx, toks).await;
+
+        assert!(fatal.is_cancelled(), "fatal cause should be cancelled");
+        assert!(root.is_cancelled(), "root token should be cancelled");
+    }
+
+    /// A collector that delivers an event every reconnect resets the failure
+    /// counter each cycle, so it must *never* escalate — it flaps indefinitely.
+    #[tokio::test(start_paused = true)]
+    async fn delivered_events_prevent_escalation() {
+        let (tx, mut rx) = broadcast::channel::<u32>(16);
+        let (toks, fatal, root) = tokens();
+        // Threshold of 2, but one event per stream keeps the counter pinned at 1.
+        let collector = Box::new(FixedThenEnd { items: vec![7] });
+
+        let handle = tokio::spawn(run(collector, config(2), tx, toks));
+
+        // Three events means three full reconnect cycles survived without Fatal.
+        for _ in 0..3 {
+            assert_eq!(rx.recv().await.unwrap(), 7);
+        }
+        assert!(!fatal.is_cancelled(), "delivering events must not escalate");
+
+        root.cancel();
+        handle.await.unwrap();
+    }
+
+    /// Cancelling the driver's own token shuts it down cleanly — it returns
+    /// without ever touching the fatal cause.
+    #[tokio::test(start_paused = true)]
+    async fn child_cancellation_shuts_down_without_fatal() {
+        let (tx, _rx) = broadcast::channel::<u32>(16);
+        let (toks, fatal, root) = tokens();
+        let collector = Box::new(EndingCollector); // would retry forever otherwise
+
+        let handle = tokio::spawn(run(collector, config(1_000), tx, toks));
+        // Let it enter its retry/backoff loop, then ask it to stop.
+        tokio::task::yield_now().await;
+        root.cancel();
+
+        handle.await.unwrap();
+        assert!(
+            !fatal.is_cancelled(),
+            "a caller-initiated shutdown is not a fatal one"
+        );
+    }
+
+    /// Persistent stream-*creation* failure escalates to Fatal just like a
+    /// persistent stream-*end* — both feed the one counter.
+    #[tokio::test(start_paused = true)]
+    async fn creation_failure_escalates_to_fatal() {
+        /// A collector whose `subscribe` always fails.
+        struct FailingCollector;
+
+        #[async_trait]
+        impl Collector<u32> for FailingCollector {
+            async fn subscribe(&self) -> Result<CollectorStream<'_, u32>> {
+                Err(anyhow::anyhow!("creation failed"))
+            }
+        }
+
+        let (tx, _rx) = broadcast::channel::<u32>(16);
+        let (toks, fatal, root) = tokens();
+
+        run(Box::new(FailingCollector), config(2), tx, toks).await;
+
+        assert!(fatal.is_cancelled(), "creation failure should escalate");
+        assert!(root.is_cancelled());
+    }
+
+    /// The driver sleeps for exactly the policy's backoff curve before
+    /// escalating: with `base_delay` 1s and threshold 3, it retries after 2s
+    /// then 4s, so 6s of virtual time elapse before Fatal.
+    #[tokio::test(start_paused = true)]
+    async fn honours_the_backoff_curve_before_escalating() {
+        let (tx, _rx) = broadcast::channel::<u32>(16);
+        let (toks, _fatal, _root) = tokens();
+        let config = ReconnectConfig {
+            max_failures: 3,
+            base_delay: Duration::from_secs(1),
+        };
+
+        let start = tokio::time::Instant::now();
+        run(Box::new(EndingCollector), config, tx, toks).await;
+
+        assert_eq!(start.elapsed(), Duration::from_secs(6));
+    }
+}


### PR DESCRIPTION
Lift orchestration out of the ~210-line Engine::run monolith into two deep, independently-testable modules:

- engine/driver.rs (Collector Driver): owns one Collector's full lifecycle — subscribe, pump events into the broadcast channel, and on a lost or failed stream consult the per-collector ReconnectPolicy to retry-after-backoff or escalate. The two-step fatal/root cancellation is consolidated into one `escalate` helper instead of two duplicated sites. The reconnect-driving loop is now unit-testable without a live engine (incl. backoff timing under tokio paused time).

- engine/channel.rs (into_stream): folds lag-logging, channel close, and cooperative cancellation into a single Stream, collapsing the near-identical strategy/executor select-loops to a plain `while let Some(item)`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core engine task wiring and collector fatal-escalation paths; behavior is intended to match the prior inline loop but deserves regression scrutiny on reconnect and shutdown semantics.
> 
> **Overview**
> **Refactors `Engine::run`** by pulling collector lifecycle and broadcast consumer loops into dedicated modules, with docs and tests aligned to a **Collector Driver** term.
> 
> **Collector Driver** (`engine/driver.rs`): The inline subscribe → pump → reconnect loop moves out of the engine into `driver::run`, which owns `ReconnectPolicy` decisions, backoff sleeps, and a single **`escalate`** helper (fatal token, then root). The engine only spawns one driver task per collector.
> 
> **Broadcast adapter** (`engine/channel.rs`): **`into_stream`** wraps strategy/executor `broadcast::Receiver`s into a `Stream` that logs lag, stops on channel close, and respects cancellation. Executor and strategy tasks become simple `while let Some(...)` loops instead of duplicated `select!` blocks.
> 
> **Strategy shutdown**: When draining per-event action streams, the loop now uses **`take_until`** on the child cancel token so shutdown can interrupt a long action stream instead of finishing it first.
> 
> **Tests & tooling**: Unit tests cover the channel adapter and driver (pumping, fatal vs cooperative cancel, creation failure, backoff under **`tokio::test(start_paused = true)`**). **`Cargo.toml`** adds `tokio` dev-dependency with **`test-util`**. **`CONTEXT.md`** documents Collector Driver and updated Engine ↔ policy relationships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 471bf98651af22fbbf4d5158ed577ab6ae7a2811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->