### PR TITLE
refactor: name the Persisted subscription's three-segment contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,10 +29,30 @@ _Avoid_: supervisor, collector task, reconnect loop
 The Reconnect Policy's verdict that a Collector cannot recover. The Engine responds by cancelling a dedicated, observe-only **fatal token** (the reason) and then the root token (tearing down every task), so the binary can tell a fatal shutdown apart from a caller-initiated one and restart the process with a fresh sync — never by killing the host process itself.
 _Avoid_: crash, panic, die
 
+**Persisted Collector**:
+A Collector wrapper that records every event it sees into a Store and, on subscribe, delivers three **Segments** in fixed order: **Replay**, then **Backfill**, then the **Live Tail**.
+_Avoid_: indexer, archiver, recorder
+
+**Segment**:
+One of the three ordered parts of a Persisted Collector's subscription. The order — Replay → Backfill → Live Tail — is fixed; the Segments are disjoint, split at the chain tip observed during subscribe.
+
+**Replay**:
+The Segment that reconstructs stored history from the Store. Runs only on the **first** subscribe (replay-once): on a reconnect the Engine subscribes again, and re-emitting the archive would re-deliver every historical event to Strategies.
+_Avoid_: re-emit, history dump
+
+**Backfill**:
+The Segment that fetches the gap between the last stored block and the chain tip (`[last+1 ..= tip]`) from the source. These are complete blocks, so all of them — including the trailing one — are persisted.
+_Avoid_: catch-up, gap fill
+
+**Live Tail**:
+The unbounded Segment following the chain tip, strictly above the Backfill's cut (`> tip`). Its final in-progress block is never flushed to the Store; a restart re-fetches it via Backfill.
+_Avoid_: live stream, subscription
+
 ## Relationships
 
 - An **Engine** spawns one **Collector Driver** per **Collector**; each Driver owns one **Reconnect Policy** instance.
 - A **Reconnect Policy** counts consecutive stream failures and resets that count only when its **Collector Driver** reports a delivered event.
+- A **Persisted Collector** pairs one **Collector** (block-aware) with one Store; its subscription is the chain Replay → Backfill → Live Tail.
 - A **Fatal** verdict cancels the observe-only fatal token, then the root token shared by all **Collector**, **Strategy**, and **Executor** tasks; the binary observes the fatal token and decides to exit.
 
 ## Example dialogue

--- a/docs/adr/0001-persisted-subscribe-stays-inline.md
+++ b/docs/adr/0001-persisted-subscribe-stays-inline.md
@@ -1,0 +1,26 @@
+# Persisted::subscribe stays an inline interpreter — no plan/execute split
+
+`Persisted::subscribe` is a ~60-line orchestration method that composes three
+Segments (Replay → Backfill → Live Tail) with the boundary arithmetic and
+ordering invariants explained in comments. That shape pattern-matches to a
+plan/execute refactor: extract a pure `plan(first_subscribe, last, tip) ->
+SubscribePlan` whose fields encode the segment boundaries, test it directly,
+and shrink `subscribe` to an interpreter.
+
+We considered exactly that and rejected it. The extractable arithmetic is one
+`+1` and one `> tip` — a pure plan module fails the deletion test (single
+caller, near-zero conceptual mass), and its unit tests would be tautological
+with its implementation. The invariants that actually carry risk are
+I/O-ordering, which a pure plan cannot hold: subscribe to the live source
+*before* querying the tip (so head events are buffered, not lost), and flip
+the replay-once flag only *after* every fallible setup step (so a failed
+subscribe doesn't strand stored history on retry). Those are already guarded
+by tests through the `Collector` interface (`tests/persistence.rs`, e.g.
+`failed_subscribe_does_not_consume_replay`).
+
+Instead, the segment contract is named structurally: the private `Segments`
+struct in `src/persistence/persisted.rs` owns the delivery order in
+`into_stream()`, and the arithmetic stays at the construction site with its
+comments. Don't re-propose extracting the orchestration into a pure plan
+unless the boundary logic grows real mass (e.g. per-log identity for
+overlap-and-dedup at the tip cut, deferred in PR #18).

--- a/src/persistence/persisted.rs
+++ b/src/persistence/persisted.rs
@@ -67,6 +67,33 @@ impl<C, S> Persisted<C, S> {
     }
 }
 
+/// The three segments of a [`Persisted`] subscription, in delivery order.
+///
+/// Construction forces an editor to account for every segment; the order in
+/// which they reach the subscriber is fixed in exactly one place,
+/// [`Segments::into_stream`]. The boundary arithmetic that keeps the segments
+/// disjoint lives at the construction site in [`Persisted::subscribe`].
+struct Segments<'a, E> {
+    /// Stored history reconstructed from the database. Empty on every
+    /// subscribe after the first (see the replay-once flag on [`Persisted`]).
+    replay: CollectorStream<'a, E>,
+    /// The RPC gap `[last+1 ..= tip]`: complete blocks, so the trailing block
+    /// is flushed too.
+    backfill: CollectorStream<'a, E>,
+    /// The unbounded live tail, strictly above the backfill cut (`> tip`); its
+    /// final in-progress block is never flushed.
+    live: CollectorStream<'a, E>,
+}
+
+impl<'a, E: Send + 'a> Segments<'a, E> {
+    /// Deliver replay, then backfill, then live. Replay and backfill must
+    /// precede the live tail so strategies see history in block order, and the
+    /// live tail must come last because it never ends.
+    fn into_stream(self) -> CollectorStream<'a, E> {
+        Box::pin(self.replay.chain(self.backfill).chain(self.live))
+    }
+}
+
 #[async_trait]
 impl<C, S, E> Collector<E> for Persisted<C, S>
 where
@@ -90,7 +117,7 @@ where
         //    event to strategies, so subsequent subscribes skip replay and let
         //    the backfill segment cover only the gap since the last stored block.
         let first_subscribe = !self.replayed.load(Ordering::SeqCst);
-        let replayed: CollectorStream<'_, E> = if first_subscribe {
+        let replay: CollectorStream<'_, E> = if first_subscribe {
             replay_stored::<E, S>(&self.store, table, last).await?
         } else {
             Box::pin(futures::stream::empty()) as CollectorStream<'_, E>
@@ -133,7 +160,12 @@ where
         })) as CollectorStream<'_, (u64, E)>;
         let live = persist_and_emit(live_source, &self.store, false);
 
-        Ok(Box::pin(replayed.chain(backfill).chain(live)))
+        Ok(Segments {
+            replay,
+            backfill,
+            live,
+        }
+        .into_stream())
     }
 }
 


### PR DESCRIPTION
Introduce a private Segments struct in persisted.rs so the replay -> backfill -> live delivery order is fixed in one named place (Segments::into_stream) instead of anonymous .chain() calls; each segment's contract moves onto the field docs. Behaviour unchanged — the Collector interface and all existing tests are untouched.

Add the segment vocabulary (Persisted Collector, Segment, Replay, Backfill, Live Tail) to CONTEXT.md, and record ADR-0001: the plan/execute split was considered and rejected because the extractable arithmetic fails the deletion test while the risk-carrying invariants are I/O-ordering a pure plan cannot hold.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor and documentation only; subscribe ordering and persistence logic are unchanged and existing Collector/persistence tests are untouched.
> 
> **Overview**
> Names the **Persisted** subscribe contract without changing runtime behavior: a private **`Segments`** struct holds **replay → backfill → live** streams, and **`Segments::into_stream()`** is the single place that chains them (replacing inline `.chain()` on anonymous locals). Segment semantics move onto field docs; the replay stream local is renamed from `replayed` to **`replay`**.
> 
> **`CONTEXT.md`** adds shared vocabulary (**Persisted Collector**, **Segment**, **Replay**, **Backfill**, **Live Tail**) and a relationship note. **ADR-0001** records why **`Persisted::subscribe`** stays an inline orchestrator rather than a plan/execute split (minimal pure arithmetic vs. I/O-ordering invariants already covered by persistence tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e17be6ce16902474c0fbd7ea6c4c7091f149d4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->