### PR TITLE
refactor: proper merge and chain combinators

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,6 +29,14 @@ _Avoid_: supervisor, collector task, reconnect loop
 The Reconnect Policy's verdict that a Collector cannot recover. The Engine responds by cancelling a dedicated, observe-only **fatal token** (the reason) and then the root token (tearing down every task), so the binary can tell a fatal shutdown apart from a caller-initiated one and restart the process with a fresh sync — never by killing the host process itself.
 _Avoid_: crash, panic, die
 
+**Merge**:
+A combinator that interleaves two or more Collectors into one composite Collector. Events arrive in whichever order the sources produce them. All sources subscribe eagerly when the composite subscribes; any creation failure fails the composite's subscribe, so the failure feeds the Reconnect Policy's counter instead of vanishing.
+_Avoid_: combine, join, fan-in (the Engine's channel-level fan-in is a different thing)
+
+**Chain**:
+A combinator that delivers two or more Collectors' streams strictly in sequence — the next source's events are held back until the previous source's stream ends. Sources still subscribe eagerly at the composite's subscribe, so a later live source buffers at its source rather than missing events while earlier segments drain (the same head-buffering rationale as the Persisted Collector's subscribe). Any creation failure fails the whole subscribe.
+_Avoid_: concat, append
+
 **Persisted Collector**:
 A Collector wrapper that records every event it sees into a Store and, on subscribe, delivers three **Segments** in fixed order: **Replay**, then **Backfill**, then the **Live Tail**.
 _Avoid_: indexer, archiver, recorder
@@ -51,6 +59,7 @@ _Avoid_: live stream, subscription
 ## Relationships
 
 - An **Engine** spawns one **Collector Driver** per **Collector**; each Driver owns one **Reconnect Policy** instance.
+- A **Merge** or **Chain** composite is one **Collector** to the **Engine**: its sources share one **Collector Driver** and one **Reconnect Policy** (one lifecycle). Register sources as separate Collectors instead when each should reconnect — and go **Fatal** — independently.
 - A **Reconnect Policy** counts consecutive stream failures and resets that count only when its **Collector Driver** reports a delivered event.
 - A **Persisted Collector** pairs one **Collector** (block-aware) with one Store; its subscription is the chain Replay → Backfill → Live Tail.
 - A **Fatal** verdict cancels the observe-only fatal token, then the root token shared by all **Collector**, **Strategy**, and **Executor** tasks; the binary observes the fatal token and decides to exit.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "wasmtimer",
 ]
@@ -456,7 +456,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "tracing-futures",
  "url",
@@ -707,7 +707,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "url",
  "wasmtimer",
@@ -723,7 +723,7 @@ dependencies = [
  "alloy-transport",
  "reqwest",
  "serde_json",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "url",
 ]
@@ -945,7 +945,6 @@ dependencies = [
  "async-stream",
  "async-trait",
  "futures",
- "jsonrpsee",
  "serde",
  "serde_json",
  "sqlx",
@@ -1007,12 +1006,6 @@ checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auto_impl"
@@ -1195,12 +1188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,16 +1204,6 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.1.1",
-]
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
 ]
 
 [[package]]
@@ -1282,16 +1259,6 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1802,16 +1769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-dependencies = [
- "gloo-timers",
- "send_wrapper 0.4.0",
-]
-
-[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,52 +1839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
-name = "gloo-net"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils",
- "http",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,25 +1847,6 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.9.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -2096,7 +1988,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -2105,23 +1996,6 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
 ]
 
 [[package]]
@@ -2386,28 +2260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,131 +2267,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonrpsee"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b26c20e2178756451cfeb0661fb74c47dd5988cb7e3939de7e9241fd604d42"
-dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-http-client",
- "jsonrpsee-types",
- "jsonrpsee-wasm-client",
- "jsonrpsee-ws-client",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bacb85abf4117092455e1573625e21b8f8ef4dec8aff13361140b2dc266cdff2"
-dependencies = [
- "base64",
- "futures-channel",
- "futures-util",
- "gloo-net",
- "http",
- "jsonrpsee-core",
- "pin-project",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "soketto",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456196007ca3a14db478346f58c7238028d55ee15c1df15115596e411ff27925"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-timer",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "jsonrpsee-types",
- "pin-project",
- "rustc-hash",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c872b6c9961a4ccc543e321bb5b89f6b2d2c7fe8b61906918273a3333c95400c"
-dependencies = [
- "async-trait",
- "base64",
- "http-body",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "rustls",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a8e70baf945b6b5752fc8eb38c918a48f1234daf11355e07106d963f860089"
-dependencies = [
- "http",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "jsonrpsee-wasm-client"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6558a9586cad43019dafd0b6311d0938f46efc116b34b28c74778bc11a2edf6"
-dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b3323d890aa384f12148e8d2a1fd18eb66e9e7e825f9de4fa53bcc19b93eef"
-dependencies = [
- "http",
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "url",
 ]
 
 [[package]]
@@ -2721,7 +2448,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3308,7 +3035,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.2",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3459,25 +3186,12 @@ version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -3497,33 +3211,6 @@ checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework 3.2.0",
- "security-framework-sys",
- "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3559,15 +3246,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -3627,20 +3305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3679,12 +3344,6 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
-
-[[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "send_wrapper"
@@ -3869,21 +3528,6 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "soketto"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
-dependencies = [
- "base64",
- "bytes",
- "futures",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
 ]
 
 [[package]]
@@ -4422,7 +4066,6 @@ checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4443,21 +4086,6 @@ dependencies = [
  "indexmap 2.9.0",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -4676,16 +4304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4811,24 +4429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.0",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4861,15 +4461,6 @@ name = "widestring"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "windows-core"
@@ -4958,15 +4549,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -4999,21 +4581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5065,12 +4632,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -5089,12 +4650,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5110,12 +4665,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5149,12 +4698,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5170,12 +4713,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5197,12 +4734,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5218,12 +4749,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5279,7 +4804,7 @@ dependencies = [
  "log",
  "pharos",
  "rustc_version 0.4.1",
- "send_wrapper 0.6.0",
+ "send_wrapper",
  "thiserror 1.0.69",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ futures = "0.3"
 tokio = { version = "1.44", features = ["full"] }
 tokio-stream = { version = "0.1", features = ['sync'] }
 tokio-util = "0.7"
-jsonrpsee = { version = "0.24", features = ["client", "async-client"] }
 alloy = { version = "1.0", features = [
     "full",
     "node-bindings",

--- a/src/collector_ext.rs
+++ b/src/collector_ext.rs
@@ -1,9 +1,11 @@
 use crate::types::Collector;
 
+mod chain;
 mod filter_map;
 mod map;
 mod merge;
 
+pub use chain::*;
 pub use filter_map::*;
 pub use map::*;
 pub use merge::*;
@@ -28,12 +30,22 @@ pub trait CollectorExt<E>: Collector<E> + Send + Sync + Sized + 'static {
         FilterMap::new(Box::new(self), f)
     }
 
-    /// Merge two collectors into a single collector that emits events from both.
+    /// Interleave this collector with `other`: events arrive in whichever
+    /// order the sources produce them. See [`Merge`] for the full contract.
     fn merge<C>(self, other: C) -> Merge<Self, C>
     where
         C: Collector<E> + Send + Sync + 'static,
     {
         Merge::new(self, other)
+    }
+
+    /// Deliver all of this collector's events, then all of `other`'s. Both
+    /// subscribe eagerly. See [`Chain`] for the full contract.
+    fn chain<C>(self, other: C) -> Chain<Self, C>
+    where
+        C: Collector<E> + Send + Sync + 'static,
+    {
+        Chain::new(self, other)
     }
 }
 
@@ -41,30 +53,182 @@ impl<T: Collector<E> + 'static, E> CollectorExt<E> for T {}
 
 #[cfg(test)]
 mod test {
-    use super::CollectorExt;
+    use super::{CollectorExt, chain_all, merge_all};
     use crate::types::{Collector, CollectorStream};
     use anyhow::Result;
     use async_trait::async_trait;
     use futures::stream;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
     use tokio_stream::StreamExt;
     use tokio_stream::{self};
 
-    pub struct TestCollector {
-        data: Vec<u8>,
+    pub struct TestCollector<T> {
+        data: Vec<T>,
     }
 
-    impl TestCollector {
-        pub fn new(data: Vec<u8>) -> Self {
+    impl<T> TestCollector<T> {
+        pub fn new(data: Vec<T>) -> Self {
             Self { data }
         }
     }
 
-    /// Implementation of the [Collector](Collector) trait for the [BlockCollector](BlockCollector).
     #[async_trait]
-    impl Collector<u8> for TestCollector {
-        async fn subscribe(&self) -> Result<CollectorStream<'_, u8>> {
+    impl<T: Clone + Send + Sync + 'static> Collector<T> for TestCollector<T> {
+        async fn subscribe(&self) -> Result<CollectorStream<'_, T>> {
             Ok(Box::pin(stream::iter(self.data.clone())))
         }
+    }
+
+    /// Emits its events, then stays pending forever — a live source that never
+    /// ends, for proving delivery happens before any stream end.
+    pub struct PendingCollector<T> {
+        data: Vec<T>,
+    }
+
+    impl<T> PendingCollector<T> {
+        pub fn new(data: Vec<T>) -> Self {
+            Self { data }
+        }
+    }
+
+    #[async_trait]
+    impl<T: Clone + Send + Sync + 'static> Collector<T> for PendingCollector<T> {
+        async fn subscribe(&self) -> Result<CollectorStream<'_, T>> {
+            Ok(Box::pin(
+                stream::iter(self.data.clone()).chain(stream::pending()),
+            ))
+        }
+    }
+
+    /// A collector whose subscribe always fails.
+    pub struct FailingCollector;
+
+    #[async_trait]
+    impl Collector<i32> for FailingCollector {
+        async fn subscribe(&self) -> Result<CollectorStream<'_, i32>> {
+            anyhow::bail!("subscribe failed")
+        }
+    }
+
+    /// Counts subscribe calls and yields an empty stream, for observing when a
+    /// combinator subscribes its sources.
+    pub struct CountingCollector {
+        subscribes: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Collector<i32> for CountingCollector {
+        async fn subscribe(&self) -> Result<CollectorStream<'_, i32>> {
+            self.subscribes.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::pin(stream::iter(Vec::new())))
+        }
+    }
+
+    /// An event type with no serde impls: combinators must not demand
+    /// (de)serializability that no behaviour needs.
+    #[derive(Clone, Debug, PartialEq)]
+    struct Opaque(u8);
+
+    #[tokio::test]
+    async fn chain_delivers_sources_strictly_in_sequence() {
+        let chained = TestCollector::new(vec![1, 3, 5]).chain(TestCollector::new(vec![2, 4, 6]));
+        let stream = chained.subscribe().await.unwrap();
+        let res = stream.collect::<Vec<_>>().await;
+        assert_eq!(res, vec![1, 3, 5, 2, 4, 6]);
+    }
+
+    #[tokio::test]
+    async fn chain_subscribes_to_later_sources_eagerly() {
+        let subscribes = Arc::new(AtomicUsize::new(0));
+        let chained = TestCollector::new(vec![1]).chain(CountingCollector {
+            subscribes: Arc::clone(&subscribes),
+        });
+        let _stream = chained.subscribe().await.unwrap();
+        // The second source must be live before the first segment is consumed,
+        // so it buffers at its source instead of missing events.
+        assert_eq!(subscribes.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn chain_fails_subscribe_when_any_source_fails() {
+        let chained = TestCollector::new(vec![1]).chain(FailingCollector);
+        assert!(chained.subscribe().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn chain_all_delivers_in_registration_order() {
+        let sources: Vec<Box<dyn Collector<i32>>> = vec![
+            Box::new(TestCollector::new(vec![1, 2])),
+            Box::new(TestCollector::new(vec![3])),
+            Box::new(TestCollector::new(vec![4, 5])),
+        ];
+        let chained = chain_all(sources);
+        let stream = chained.subscribe().await.unwrap();
+        assert_eq!(stream.collect::<Vec<_>>().await, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[tokio::test]
+    async fn chain_all_fails_subscribe_when_any_source_fails() {
+        let sources: Vec<Box<dyn Collector<i32>>> = vec![
+            Box::new(TestCollector::new(vec![1])),
+            Box::new(FailingCollector),
+        ];
+        assert!(chain_all(sources).subscribe().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn merge_does_not_require_deserializable_events() {
+        let merged = TestCollector::new(vec![Opaque(1)]).merge(TestCollector::new(vec![Opaque(2)]));
+        let stream = merged.subscribe().await.unwrap();
+        let mut res = stream.collect::<Vec<_>>().await;
+        res.sort_by_key(|o| o.0);
+        assert_eq!(res, vec![Opaque(1), Opaque(2)]);
+    }
+
+    #[tokio::test]
+    async fn merge_delivers_from_both_sources_before_either_ends() {
+        let merged = PendingCollector::new(vec![1]).merge(PendingCollector::new(vec![2]));
+        let stream = merged.subscribe().await.unwrap();
+        let mut res = tokio::time::timeout(
+            Duration::from_secs(1),
+            stream.take(2).collect::<Vec<_>>(),
+        )
+        .await
+        .expect("merge starved a source: both events must arrive while neither stream has ended");
+        res.sort();
+        assert_eq!(res, vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn merge_all_delivers_from_every_source_before_any_ends() {
+        let sources: Vec<Box<dyn Collector<i32>>> = vec![
+            Box::new(PendingCollector::new(vec![1])),
+            Box::new(PendingCollector::new(vec![2])),
+            Box::new(PendingCollector::new(vec![3])),
+        ];
+        let merged = merge_all(sources);
+        let stream = merged.subscribe().await.unwrap();
+        let mut res =
+            tokio::time::timeout(Duration::from_secs(1), stream.take(3).collect::<Vec<_>>())
+                .await
+                .expect(
+                    "merge_all starved a source: all events must arrive while no stream has ended",
+                );
+        res.sort();
+        assert_eq!(res, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn merge_all_fails_subscribe_when_any_source_fails() {
+        let sources: Vec<Box<dyn Collector<i32>>> = vec![
+            Box::new(TestCollector::new(vec![1])),
+            Box::new(FailingCollector),
+        ];
+        assert!(merge_all(sources).subscribe().await.is_err());
     }
 
     #[tokio::test]
@@ -87,28 +251,6 @@ mod test {
         let stream = collector.subscribe().await.unwrap();
         let event = stream.collect::<Vec<_>>().await;
         assert_eq!(event, vec![2, 4]);
-    }
-
-    #[tokio::test]
-    async fn test_vec_merge_collector() {
-        let block_collector = TestCollector::new(vec![1, 3, 5]);
-        let block_collector_2 = TestCollector::new(vec![2, 4, 6]);
-        let block_collector_3 = TestCollector::new(vec![7]);
-
-        let collectors = vec![
-            Box::new(block_collector),
-            Box::new(block_collector_2),
-            Box::new(block_collector_3),
-        ];
-
-        let mut res = collectors
-            .subscribe()
-            .await
-            .unwrap()
-            .collect::<Vec<_>>()
-            .await;
-        res.sort();
-        assert_eq!(res, vec![1, 2, 3, 4, 5, 6, 7])
     }
 
     #[tokio::test]

--- a/src/collector_ext/chain.rs
+++ b/src/collector_ext/chain.rs
@@ -1,0 +1,69 @@
+use crate::types::{Collector, CollectorStream};
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::StreamExt;
+
+/// Delivers two [Collector]s' streams strictly in sequence: `second`'s events
+/// are held back until `first`'s stream ends.
+///
+/// Both sources subscribe when the composite subscribes — eagerly, so a later
+/// live source buffers at its source rather than missing events while the
+/// earlier segment drains (the same head-buffering rationale as the Persisted
+/// Collector's subscribe). That buffering is bounded by what the source
+/// retains: a lossy source (e.g. a lagging broadcast channel) can still drop
+/// events it produced while held back. Either subscribe failing fails the
+/// whole subscribe, so the failure reaches the Reconnect Policy instead of
+/// vanishing. To the Engine the composite is one Collector — one Collector
+/// Driver, one Reconnect Policy, one lifecycle shared by both sources.
+pub struct Chain<C1, C2> {
+    first: C1,
+    second: C2,
+}
+
+impl<C1, C2> Chain<C1, C2> {
+    /// Creates a new `Chain` delivering all of `first`, then all of `second`.
+    pub fn new(first: C1, second: C2) -> Self {
+        Self { first, second }
+    }
+}
+
+#[async_trait]
+impl<C1, C2, E> Collector<E> for Chain<C1, C2>
+where
+    C1: Collector<E> + Send + Sync + 'static,
+    C2: Collector<E> + Send + Sync + 'static,
+    E: Send + Sync + 'static,
+{
+    async fn subscribe(&self) -> Result<CollectorStream<'_, E>> {
+        let first = self.first.subscribe().await?;
+        let second = self.second.subscribe().await?;
+        Ok(Box::pin(first.chain(second)))
+    }
+}
+
+/// [`Chain`] over a runtime-sized set of sources; see [`chain_all`].
+pub struct ChainAll<E> {
+    sources: Vec<Box<dyn Collector<E>>>,
+}
+
+/// Delivers every source's stream strictly in registration order, with the
+/// same contract as [`Chain`]: eager subscribe (later sources buffer at their
+/// source while earlier segments drain), any failure fails the whole
+/// subscribe, and the sources share one lifecycle (one Collector Driver, one
+/// Reconnect Policy).
+pub fn chain_all<E>(sources: Vec<Box<dyn Collector<E>>>) -> ChainAll<E> {
+    ChainAll { sources }
+}
+
+#[async_trait]
+impl<E: Send + Sync + 'static> Collector<E> for ChainAll<E> {
+    async fn subscribe(&self) -> Result<CollectorStream<'_, E>> {
+        let mut streams = Vec::with_capacity(self.sources.len());
+        for source in &self.sources {
+            streams.push(source.subscribe().await?);
+        }
+        // The sources are already subscribed, so flattening their streams in
+        // order is sequential delivery, not lazy subscription.
+        Ok(Box::pin(futures::stream::iter(streams).flatten()))
+    }
+}

--- a/src/collector_ext/merge.rs
+++ b/src/collector_ext/merge.rs
@@ -1,10 +1,16 @@
 use crate::types::{Collector, CollectorStream};
 use anyhow::Result;
 use async_trait::async_trait;
-use futures::{StreamExt, stream::select};
-use jsonrpsee::core::DeserializeOwned;
+use futures::stream::{select, select_all};
 
-/// Merges two [Collector]s into a single stream that interleaves events from both.
+/// Interleaves two [Collector]s into one composite Collector: events arrive in
+/// whichever order the sources produce them.
+///
+/// Both sources subscribe when the composite subscribes; either failing fails
+/// the whole subscribe, so the failure reaches the Reconnect Policy instead of
+/// vanishing. The composite stream ends only when *both* source streams have
+/// ended. To the Engine the composite is one Collector — one Collector Driver,
+/// one Reconnect Policy, one lifecycle shared by both sources.
 pub struct Merge<C1, C2> {
     this: C1,
     other: C2,
@@ -22,23 +28,36 @@ impl<C1, C2, E> Collector<E> for Merge<C1, C2>
 where
     C1: Collector<E> + Send + Sync + 'static,
     C2: Collector<E> + Send + Sync + 'static,
-    E: Send + Sync + DeserializeOwned + 'static,
+    E: Send + Sync + 'static,
 {
     async fn subscribe(&self) -> Result<CollectorStream<'_, E>> {
         let this_stream = self.this.subscribe().await?;
         let other_stream = self.other.subscribe().await?;
-        let merged = Box::pin(select(this_stream, other_stream)) as CollectorStream<'_, E>;
-        Ok(Box::pin(merged))
+        Ok(Box::pin(select(this_stream, other_stream)))
     }
 }
 
+/// [`Merge`] over a runtime-sized set of sources; see [`merge_all`].
+pub struct MergeAll<E> {
+    sources: Vec<Box<dyn Collector<E>>>,
+}
+
+/// Interleaves every source into one composite Collector, with the same
+/// contract as [`Merge`]: eager subscribe, any failure fails the whole
+/// subscribe, the composite stream ends only when every source stream has
+/// ended, and the sources share one lifecycle (one Collector Driver, one
+/// Reconnect Policy).
+pub fn merge_all<E>(sources: Vec<Box<dyn Collector<E>>>) -> MergeAll<E> {
+    MergeAll { sources }
+}
+
 #[async_trait]
-impl<E: 'static, C: Collector<E>> Collector<E> for Vec<Box<C>> {
+impl<E: Send + Sync + 'static> Collector<E> for MergeAll<E> {
     async fn subscribe(&self) -> Result<CollectorStream<'_, E>> {
-        let stream = futures::stream::iter(self.iter())
-            .then(|collector| collector.subscribe())
-            .filter_map(|result| async { result.ok() })
-            .flatten();
-        Ok(Box::pin(stream))
+        let mut streams = Vec::with_capacity(self.sources.len());
+        for source in &self.sources {
+            streams.push(source.subscribe().await?);
+        }
+        Ok(Box::pin(select_all(streams)))
     }
 }


### PR DESCRIPTION
…ombinators

The Vec<Box<C>> blanket Collector impl claimed fan-in but flatten() polls streams sequentially, so every source after the first was silently dead for live (unending) streams, and subscribe errors were swallowed — bypassing the Reconnect Policy's creation-failure counting. Merge also carried a stray E: DeserializeOwned bound (the crate's only jsonrpsee use) that no behaviour needed.

Replace the invisible blanket impl with two named combinators sharing one contract — eager subscribe, fail-fast on any source's subscribe error, one lifecycle (one Collector Driver, one Reconnect Policy) per composite:

- merge / merge_all: interleave sources via select/select_all; the composite stream ends only when every source stream has ended
- chain / chain_all (new): strictly sequential delivery; later sources buffer at their source while earlier segments drain (Persisted's head-buffering rationale)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how multi-source collectors subscribe and deliver events, which affects live-stream fan-in and Reconnect Policy visibility of subscribe failures; behavior is intentionally stricter than the old blanket impl.
> 
> **Overview**
> Replaces the broken **`Vec<Box<dyn Collector>>`** fan-in (sequential `flatten` starved live sources after the first; subscribe errors were dropped) with explicit **`merge` / `merge_all`** and new **`chain` / `chain_all`** combinators on **`CollectorExt`**.
> 
> Both shapes share one contract: **eager subscribe** on every source, **fail-fast** if any `subscribe` fails (so the Reconnect Policy sees creation failures), and **one Engine lifecycle** per composite (single Collector Driver / Reconnect Policy). **Merge** interleaves via `select` / `select_all`; **Chain** delivers sources strictly in order while still subscribing later sources up front so live tails buffer at the source. **`Merge`** no longer requires **`DeserializeOwned`**; **`jsonrpsee`** is removed from **`Cargo.toml`**. **`CONTEXT.md`** adds **Merge** and **Chain** vocabulary and notes when to register sources separately for independent reconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1774fd4a561917eac8b394505b82662f00d0ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->