### PR TITLE
refactor: remove vestigial public surface from the core types module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,4 +42,3 @@ pub mod persistence;
 
 /// This module contains syntax extensions for the `Collector` trait.
 pub mod collector_ext;
-// pub use collector_ext::*;

--- a/src/persistence/persisted.rs
+++ b/src/persistence/persisted.rs
@@ -108,33 +108,6 @@ impl<'a, E: Send + 'a> Segments<'a, E> {
     }
 }
 
-/// The three segments of a [`Persisted`] subscription, in delivery order.
-///
-/// Construction forces an editor to account for every segment; the order in
-/// which they reach the subscriber is fixed in exactly one place,
-/// [`Segments::into_stream`]. The boundary arithmetic that keeps the segments
-/// disjoint lives at the construction site in [`Persisted::subscribe`].
-struct Segments<'a, E> {
-    /// Stored history reconstructed from the database. Empty on every
-    /// subscribe after the first (see the replay-once flag on [`Persisted`]).
-    replay: CollectorStream<'a, E>,
-    /// The RPC gap `[last+1 ..= tip]`: complete blocks, so the trailing block
-    /// is flushed too.
-    backfill: CollectorStream<'a, E>,
-    /// The unbounded live tail, strictly above the backfill cut (`> tip`); its
-    /// final in-progress block is never flushed.
-    live: CollectorStream<'a, E>,
-}
-
-impl<'a, E: Send + 'a> Segments<'a, E> {
-    /// Deliver replay, then backfill, then live. Replay and backfill must
-    /// precede the live tail so strategies see history in block order, and the
-    /// live tail must come last because it never ends.
-    fn into_stream(self) -> CollectorStream<'a, E> {
-        Box::pin(self.replay.chain(self.backfill).chain(self.live))
-    }
-}
-
 #[async_trait]
 impl<C, S, E> Collector<E> for Persisted<C, S>
 where

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,12 +1,7 @@
-use alloy::rpc::types::Transaction;
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::Stream;
 use std::pin::Pin;
-
-use crate::collectors::NewBlock;
-
-use crate::executors::SubmitTxToMempool;
 
 /// A stream of events emitted by a [Collector].
 pub type CollectorStream<'a, E> = Pin<Box<dyn Stream<Item = E> + Send + 'a>>;
@@ -42,49 +37,6 @@ pub trait Strategy<E, A>: Send + Sync {
 pub trait Executor<A>: Send + Sync {
     /// Execute an action.
     async fn execute(&mut self, action: A) -> Result<()>;
-}
-
-/// A wrapper around an [Executor] that filter-maps incoming actions,
-/// silently dropping actions that map to `None`.
-pub struct ExecutorFilterMap<E, F> {
-    executor: E,
-    f: F,
-}
-
-impl<E, F> ExecutorFilterMap<E, F> {
-    /// Creates a new `ExecutorFilterMap` wrapping `executor` with the filter-map function `f`.
-    pub fn new(executor: E, f: F) -> Self {
-        Self { executor, f }
-    }
-}
-
-#[async_trait]
-impl<A1, A2, E, F> Executor<A1> for ExecutorFilterMap<E, F>
-where
-    E: Executor<A2> + Send + Sync + 'static,
-    F: Fn(A1) -> Option<A2> + Send + Sync + Clone + 'static,
-    A1: Send + Sync + 'static,
-    A2: Send + Sync + 'static,
-{
-    async fn execute(&mut self, action: A1) -> Result<()> {
-        let action = (self.f)(action);
-        match action {
-            Some(action) => self.executor.execute(action).await,
-            None => Ok(()),
-        }
-    }
-}
-
-/// Convenience enum containing all the events that can be emitted by collectors.
-pub enum Events {
-    NewBlock(NewBlock),
-    Transaction(Box<Transaction>),
-}
-
-/// Convenience enum containing all the actions that can be executed by executors.
-pub enum Actions {
-    //    FlashbotsBundle(FlashbotsBundle),
-    SubmitTxToMempool(SubmitTxToMempool),
 }
 
 /// A passive consumer of the pipeline: sees every event fanned to


### PR DESCRIPTION
ExecutorFilterMap, Events, and Actions had zero callers in src, tests, or examples — fork leftovers (Actions still carried a commented-out FlashbotsBundle variant) that sat among the core traits and made the supported interface indistinguishable from residue. Delete them, along with the imports they alone justified.

Also make the ext-module export policy uniform: strategy_ext and executor_ext were glob-exported from the crate root while collector_ext sat namespaced behind a commented-out glob. All three are now plain `pub mod`s, matching collectors/executors/persistence; every in-repo consumer already imported via namespaced paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal and module export cleanup with no in-repo callers of the deleted APIs.
> 
> **Overview**
> Removes unused fork leftovers from `types`: **`ExecutorFilterMap`**, the **`Events`** / **`Actions`** convenience enums (including dead Flashbots-related residue), and imports that existed only for those types. The public core surface is now the stream aliases, **Collector** / **Strategy** / **Executor**, and **Observer**.
> 
> Aligns extension modules with **collectors** / **executors** / **persistence** by dropping the commented `pub use collector_ext::*` re-export at the crate root so **collector_ext** stays a namespaced `pub mod` only.
> 
> Fixes an accidental duplicate **`Segments`** definition in `persistence/persisted.rs` (same struct and `into_stream` impl appeared twice).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e2bbd4a98449ab967a6771c969f40125108c69f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->