### PR TITLE
fix: stop losing events at startup and stranding replay under composi…

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -200,6 +200,20 @@ where
             });
         }
 
+        // Subscribe every strategy's broadcast receiver *before* spawning any
+        // collector. A tokio broadcast channel only retains messages for
+        // receivers that already exist; a receiver created lazily in the sync
+        // loop below would miss every event broadcast before its turn came up —
+        // a deterministic loss for all but the first strategy, since each
+        // strategy syncs (and collectors emit) before the next strategy's
+        // receiver exists. Creating them all up front means events broadcast
+        // during any strategy's sync are buffered for every strategy.
+        let strategies: Vec<_> = self
+            .strategies
+            .into_iter()
+            .map(|strategy| (strategy, event_sender.subscribe()))
+            .collect();
+
         // Spawn collectors so WS subscriptions are active during strategy sync.
         //
         // Each collector is handed to a [`Collector Driver`](driver), which owns
@@ -222,11 +236,11 @@ where
             ));
         }
 
-        // Subscribe each strategy to the event channel before syncing so that
-        // events produced by collectors during sync are buffered in the receiver.
-        // Cancellation is respected during sync via the token.
-        for mut strategy in self.strategies {
-            let event_receiver = event_sender.subscribe();
+        // Sync each strategy and spawn its task. The receiver was subscribed
+        // above, before any collector could emit, so events produced during
+        // sync are buffered for it. Cancellation is respected during sync via
+        // the token.
+        for (mut strategy, event_receiver) in strategies {
             let action_sender = action_sender.clone();
             let child = token.child_token();
 

--- a/src/persistence/persisted.rs
+++ b/src/persistence/persisted.rs
@@ -136,7 +136,25 @@ where
         //    the backfill segment cover only the gap since the last stored block.
         let first_subscribe = !self.replayed.load(Ordering::SeqCst);
         let replay: CollectorStream<'_, E> = if first_subscribe {
-            replay_stored::<E, S>(&self.store, table, last).await?
+            let inner = replay_stored::<E, S>(&self.store, table, last).await?;
+            // Flip the replay-once flag when the archive is first *consumed*,
+            // not merely when `subscribe` succeeds. The engine retries
+            // `subscribe` on error, but it also discards the returned stream
+            // when a *sibling* fails the composite subscribe — e.g. this
+            // `Persisted` chained or merged with another collector, where the
+            // other source's subscribe errors after this one already succeeded.
+            // In that case the stream is dropped without ever being polled, so
+            // flipping the flag eagerly here would make the retry skip the DB
+            // replay while backfill covers only blocks after `last` — stranding
+            // the stored history. A zero-item stream that sets the flag on its
+            // first poll, chained ahead of the real replay, ties the flip to
+            // actual consumption.
+            let replayed = &self.replayed;
+            let mark = futures::stream::poll_fn(move |_| {
+                replayed.store(true, Ordering::SeqCst);
+                std::task::Poll::Ready(None::<E>)
+            });
+            Box::pin(mark.chain(inner)) as CollectorStream<'_, E>
         } else {
             Box::pin(futures::stream::empty()) as CollectorStream<'_, E>
         };
@@ -146,15 +164,6 @@ where
         let backfill_from = last.map(|l| l + 1).unwrap_or(0);
         let backfill_source = self.collector.query_range(backfill_from, tip).await?;
         let backfill = persist_and_emit(backfill_source, &self.store, self.schema.as_ref(), true);
-
-        // Only now — after every fallible setup step has succeeded — mark the
-        // replay segment as consumed. The engine retries `subscribe` when it
-        // returns an error, so flipping this flag earlier (e.g. right after
-        // `replay_stored`) would make a retry skip the DB replay while backfill
-        // covers only blocks after `last`, stranding the stored history.
-        if first_subscribe {
-            self.replayed.store(true, Ordering::SeqCst);
-        }
 
         // 3. Live tail, strictly above the backfill cut so the two segments are
         //    disjoint. A live subscription streams from "now", whose lower edge

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -669,6 +669,135 @@ mod engine_tests {
         while handle.tasks.join_next().await.is_some() {}
     }
 
+    /// Every strategy must see every event, including ones a collector emits
+    /// while *another* strategy is still syncing. A strategy's broadcast
+    /// receiver must therefore exist before any collector can emit — not be
+    /// created lazily as each strategy's turn comes up in the sync loop, which
+    /// would deterministically lose to the second strategy every event
+    /// broadcast during the first strategy's sync. Regression test for the
+    /// subscribe-after-send startup race.
+    #[tokio::test]
+    async fn test_engine_strategies_dont_miss_events_emitted_during_sync() {
+        use std::time::Duration;
+        use tokio::sync::{Notify, mpsc};
+
+        /// Emits `[1, 2, 3]` only after `gate` fires, then signals `emitted`.
+        /// Gating emission on a signal removes any race between collector start
+        /// and receiver creation, isolating the ordering bug under test.
+        struct GatedCollector {
+            gate: Arc<Notify>,
+            emitted: Arc<Notify>,
+        }
+
+        #[async_trait]
+        impl Collector<u32> for GatedCollector {
+            async fn subscribe(&self) -> Result<CollectorStream<'_, u32>> {
+                let gate = self.gate.clone();
+                let emitted = self.emitted.clone();
+                let stream = async_stream::stream! {
+                    gate.notified().await;
+                    for i in [1u32, 2, 3] {
+                        yield i;
+                    }
+                    // All three events have now been broadcast; release the
+                    // strategy whose sync opened the gate.
+                    emitted.notify_one();
+                };
+                Ok(Box::pin(stream))
+            }
+        }
+
+        /// Opens the gate during sync, then waits until the collector reports it
+        /// has broadcast every event — so all three are on the channel before
+        /// this strategy's sync returns and the *next* strategy is registered.
+        struct GateOpeningStrategy {
+            gate: Arc<Notify>,
+            emitted: Arc<Notify>,
+            seen: mpsc::UnboundedSender<u32>,
+        }
+
+        #[async_trait]
+        impl Strategy<u32, u32> for GateOpeningStrategy {
+            async fn sync_state(&mut self) -> Result<()> {
+                self.gate.notify_one();
+                self.emitted.notified().await;
+                Ok(())
+            }
+            async fn process_event(&mut self, event: u32) -> Result<ActionStream<'_, u32>> {
+                let _ = self.seen.send(event);
+                Ok(Box::pin(futures::stream::empty()))
+            }
+        }
+
+        /// Syncs instantly. Under the buggy ordering its receiver is created
+        /// only after the gate-opening strategy's sync completes — by which time
+        /// every event has already been broadcast and dropped.
+        struct RecordingStrategy {
+            seen: mpsc::UnboundedSender<u32>,
+        }
+
+        #[async_trait]
+        impl Strategy<u32, u32> for RecordingStrategy {
+            async fn sync_state(&mut self) -> Result<()> {
+                Ok(())
+            }
+            async fn process_event(&mut self, event: u32) -> Result<ActionStream<'_, u32>> {
+                let _ = self.seen.send(event);
+                Ok(Box::pin(futures::stream::empty()))
+            }
+        }
+
+        let gate = Arc::new(Notify::new());
+        let emitted = Arc::new(Notify::new());
+        let (tx_a, mut rx_a) = mpsc::unbounded_channel();
+        let (tx_b, mut rx_b) = mpsc::unbounded_channel();
+
+        let mut engine = Engine::<u32, u32>::default();
+        engine.add_collector(Box::new(GatedCollector {
+            gate: gate.clone(),
+            emitted: emitted.clone(),
+        }));
+        engine.add_strategy(Box::new(GateOpeningStrategy {
+            gate,
+            emitted,
+            seen: tx_a,
+        }));
+        engine.add_strategy(Box::new(RecordingStrategy { seen: tx_b }));
+
+        let mut handle = engine.run().await.unwrap();
+
+        // Collect what each strategy received, bounded so the buggy case (which
+        // delivers nothing to the second strategy) fails fast instead of hanging.
+        async fn collect_three(rx: &mut mpsc::UnboundedReceiver<u32>) -> Vec<u32> {
+            let mut got = Vec::new();
+            for _ in 0..3 {
+                match tokio::time::timeout(Duration::from_secs(2), rx.recv()).await {
+                    Ok(Some(v)) => got.push(v),
+                    _ => break,
+                }
+            }
+            got
+        }
+
+        let a = collect_three(&mut rx_a).await;
+        let b = collect_three(&mut rx_b).await;
+
+        handle.token.cancel();
+        while handle.tasks.join_next().await.is_some() {}
+
+        assert_eq!(
+            a,
+            vec![1, 2, 3],
+            "gate-opening strategy must see all events"
+        );
+        assert_eq!(
+            b,
+            vec![1, 2, 3],
+            "a strategy registered after another's sync must not miss events \
+             broadcast during that sync"
+        );
+    }
+
     /// A collector that escalates to `Fatal` *while* a strategy is still
     /// syncing. The root-token cancellation must not be reported as a generic
     /// `Err` — `run` must hand back an `EngineHandle` with `fatal` set so the

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -565,6 +565,62 @@ async fn failed_subscribe_does_not_consume_replay() {
     assert_eq!(events, vec![value_event(1), value_event(2), value_event(3)]);
 }
 
+/// A sibling collector that fails its first `subscribe` and succeeds after.
+struct FailOnceCollector {
+    failed: std::sync::atomic::AtomicBool,
+}
+
+#[async_trait]
+impl Collector<ValueSet> for FailOnceCollector {
+    async fn subscribe(&self) -> Result<CollectorStream<'_, ValueSet>> {
+        if !self.failed.swap(true, Ordering::SeqCst) {
+            anyhow::bail!("sibling subscribe fails the first time");
+        }
+        Ok(Box::pin(futures::stream::empty()))
+    }
+}
+
+/// Composing a `Persisted` collector under a combinator (here `chain`) must not
+/// strand the stored history. If a *sibling* source fails the composite
+/// `subscribe` **after** the `Persisted` source already subscribed
+/// successfully, the engine retries the whole composite — and that retry must
+/// still replay the archive. The replay-once flag must therefore be consumed by
+/// actually delivering the archive, not merely by a `subscribe` whose stream is
+/// then dropped undrained. Regression test for the replay-strand-under-
+/// composition bug.
+#[tokio::test]
+async fn composite_subscribe_failure_does_not_strand_replay() {
+    use artemis_light::collector_ext::CollectorExt;
+
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+    seed(&store, 5, 1).await;
+    seed(&store, 6, 2).await;
+
+    // Tip equals the last stored block, so there is no gap to backfill; live
+    // carries the next event.
+    let persisted = FakeCollector::default()
+        .live(vec![(7, 3)])
+        .tip(6)
+        .with_persistence(store.clone());
+    let sibling = FailOnceCollector {
+        failed: std::sync::atomic::AtomicBool::new(false),
+    };
+    let chained = persisted.chain(sibling);
+
+    // First subscribe fails: the `Persisted` source subscribes fine, then the
+    // sibling errors and fails the whole composite. The returned `Persisted`
+    // stream is dropped without ever being polled.
+    assert!(
+        chained.subscribe().await.is_err(),
+        "a failing sibling must fail the composite subscribe"
+    );
+
+    // Retry: the stored history (1, 2) must still be replayed — the first
+    // attempt's unpolled stream must not have consumed the replay-once flag.
+    let events: Vec<ValueSet> = chained.subscribe().await.unwrap().collect().await;
+    assert_eq!(events, vec![value_event(1), value_event(2), value_event(3)]);
+}
+
 /// A store that fails `write_block` for one specific block, delegating
 /// everything else to an inner [`SqliteStore`].
 struct FlakyStore {


### PR DESCRIPTION
…tion

Bug 1 (engine startup ordering): collectors were spawned before any strategy's broadcast receiver was created. A tokio broadcast channel only retains messages for receivers that already exist, so every event a collector emitted before a strategy's `subscribe()` was dropped. For the second and later strategies this was deterministic: each strategy synced (and collectors emitted) before the next strategy's receiver existed. Subscribe all strategy receivers up front, before spawning collectors, so events broadcast during any strategy's sync are buffered for every strategy.

Bug 2 (replay stranded under composition): `Persisted` flipped its replay-once flag as soon as `subscribe` succeeded. When a `Persisted` is composed under `chain`/`merge` and a sibling source fails the composite subscribe *after* this source already subscribed, the returned stream is dropped undrained and the engine retries — but the flag was already set, so the retry skipped the DB replay and stored history was lost. Flip the flag on first consumption (a zero-item stream that sets it on first poll, chained ahead of the real replay) instead of on subscribe success.

Both fixes come with deterministic regression tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes engine startup ordering and when persisted history is marked consumed—both affect event delivery at startup and on composite collector retries, though behavior is narrowed by targeted regression tests.
> 
> **Overview**
> Fixes two startup/event-loss bugs in the engine and persisted collectors.
> 
> **Engine:** All strategy `broadcast` receivers are created **before** collectors start, so events emitted while an earlier strategy is still in `sync_state` are buffered for every strategy—not dropped because a later strategy had not subscribed yet.
> 
> **`Persisted`:** The replay-once flag is set on **first consumption** of the DB replay stream (a no-item `poll_fn` chained ahead of replay), not when `subscribe` succeeds. That way a composite `chain`/`merge` subscribe that fails after `Persisted` already returned a stream (then drops it undrained) does not skip archive replay on retry.
> 
> Adds regression tests for multi-strategy sync-time events and composite subscribe failure with stranded replay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 662c943bd74c3423b96ca7051c3c5b2981c4e94a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->