### PR TITLE
fix: harden the Persisted backfill against real providers and bad writes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,7 +53,7 @@ The Segment that reconstructs stored history from the Store. Runs only on the **
 _Avoid_: re-emit, history dump
 
 **Backfill**:
-The Segment that fetches the gap between the last stored block and the chain tip (`[last+1 ..= tip]`) from the source. These are complete blocks, so all of them — including the trailing one — are persisted.
+The Segment that fetches the gap between the last stored block and the chain tip (`[last+1 ..= tip]`, never below the configured start block) from the source, sliced into bounded block-aligned chunks queried one at a time. These are complete blocks, so all of them — including the trailing one — are persisted. When there is no gap (stored height at or past the tip) no query is issued. A chunk that fails mid-backfill ends the whole subscription — live tail included — so the stored height cannot advance over the hole; the Reconnect Policy drives the resubscribe, which backfills again from the last stored block.
 _Avoid_: catch-up, gap fill
 
 **Live Tail**:

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ JSON payload is stored alongside the derived columns so replay reconstructs the
 exact event. Writes are one transaction per complete block, and the stored block
 height only advances over a gap-free prefix.
 
+The backfill is sliced into bounded `eth_getLogs` windows (default 10,000
+blocks, `.with_backfill_chunk_size(..)`) so no single call exceeds provider
+range caps, and `.with_start_block(..)` sets where the very first sync begins
+instead of genesis.
+
 See [`examples/persistence_example.rs`](examples/persistence_example.rs) for a
 runnable demo (record live events, then recover them on a simulated restart):
 

--- a/src/persistence/persisted.rs
+++ b/src/persistence/persisted.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use tokio_util::sync::CancellationToken;
 
 use super::record::{PAYLOAD_COLUMN, derive_record_with, from_payload, table_name};
 use super::schema::{Row, SqlType, SqlValue, TableSchema};
@@ -43,6 +44,10 @@ pub trait PersistExt<E>: PersistableCollector<E> + Sized {
 
 impl<E, C: PersistableCollector<E> + Sized> PersistExt<E> for C {}
 
+/// The default upper bound on blocks per backfill `query_range` call. Sized to
+/// fit within common provider `eth_getLogs` range caps.
+const DEFAULT_BACKFILL_CHUNK_SIZE: u64 = 10_000;
+
 /// A [`PersistableCollector`] paired with a [`Store`].
 pub struct Persisted<C, S> {
     collector: C,
@@ -52,6 +57,13 @@ pub struct Persisted<C, S> {
     /// exactly one event type, so the override is a plain field here — the
     /// Store never needs to know which event type a row came from.
     schema: Option<TableSchema>,
+    /// The lowest block the backfill segment may start from. With an empty
+    /// store this is where the very first sync begins (instead of genesis);
+    /// the backfill never reaches below it.
+    start_block: u64,
+    /// Upper bound on blocks per backfill `query_range` call; the gap is
+    /// sliced into windows of this size, queried one at a time.
+    backfill_chunk_size: u64,
     /// Whether stored history has already been replayed to a subscriber. The
     /// engine re-subscribes after a stream ends, and replaying the full archive
     /// on every reconnect would re-deliver the entire history to strategies —
@@ -67,6 +79,8 @@ impl<C, S> Persisted<C, S> {
             collector,
             store,
             schema: None,
+            start_block: 0,
+            backfill_chunk_size: DEFAULT_BACKFILL_CHUNK_SIZE,
             replayed: AtomicBool::new(false),
         }
     }
@@ -77,6 +91,29 @@ impl<C, S> Persisted<C, S> {
     /// payload column is always appended).
     pub fn with_schema(mut self, schema: TableSchema) -> Self {
         self.schema = Some(schema);
+        self
+    }
+
+    /// Never backfill below `block`. With an empty store, the very first sync
+    /// starts here instead of at genesis — a strategy that only cares about
+    /// recent history shouldn't have to fetch (or be able to fetch) the whole
+    /// chain. Stored history beyond this block wins: the backfill resumes from
+    /// the last stored block as usual.
+    pub fn with_start_block(mut self, block: u64) -> Self {
+        self.start_block = block;
+        self
+    }
+
+    /// Slice the backfill into `query_range` windows of at most `blocks`
+    /// blocks (default [`DEFAULT_BACKFILL_CHUNK_SIZE`]), queried one at a
+    /// time, so no single RPC call exceeds provider range caps or buffers an
+    /// unbounded result.
+    ///
+    /// # Panics
+    /// Panics if `blocks` is zero.
+    pub fn with_backfill_chunk_size(mut self, blocks: u64) -> Self {
+        assert!(blocks >= 1, "backfill chunk size must be at least 1 block");
+        self.backfill_chunk_size = blocks;
         self
     }
 }
@@ -141,10 +178,32 @@ where
             Box::pin(futures::stream::empty()) as CollectorStream<'_, E>
         };
 
-        // 2. Backfill the RPC gap `[last+1 ..= tip]`. These are complete blocks,
-        //    so the trailing block is flushed too (`flush_final = true`).
-        let backfill_from = last.map(|l| l + 1).unwrap_or(0);
-        let backfill_source = self.collector.query_range(backfill_from, tip).await?;
+        // 2. Backfill the RPC gap `[last+1 ..= tip]`, never reaching below the
+        //    configured start block. These are complete blocks, so the trailing
+        //    block is flushed too (`flush_final = true`). When the stored
+        //    height has already reached the tip (a restart within one block
+        //    interval, or a node whose tip lags the store) there is no gap, and
+        //    querying the inverted range `[tip+1 ..= tip]` would be rejected by
+        //    real providers — failing every resubscribe until the Reconnect
+        //    Policy escalates to Fatal. Skip the query instead.
+        //
+        //    The gap is sliced into bounded chunks queried one at a time; a
+        //    chunk that fails after the first cancels `poison`, which ends the
+        //    live tail too (see below).
+        let poison = CancellationToken::new();
+        let backfill_from = last.map(|l| l + 1).unwrap_or(0).max(self.start_block);
+        let backfill_source: CollectorStream<'_, (u64, E)> = if backfill_from > tip {
+            Box::pin(futures::stream::empty())
+        } else {
+            chunked_query(
+                &self.collector,
+                backfill_from,
+                tip,
+                self.backfill_chunk_size,
+                poison.clone(),
+            )
+            .await?
+        };
         let backfill = persist_and_emit(backfill_source, &self.store, self.schema.as_ref(), true);
 
         // Only now — after every fallible setup step has succeeded — mark the
@@ -172,10 +231,20 @@ where
         //    overlap the segments and de-duplicate; `(u64, E)` does not carry
         //    that today, so it is deferred rather than reversing the deliberate
         //    no-duplicate guarantee. See PR #18 / the boundary de-dup test.
-        let live_source = Box::pin(live_source.filter(move |(block, _)| {
-            let above_cut = *block > tip;
-            async move { above_cut }
-        })) as CollectorStream<'_, (u64, E)>;
+        //    The live tail ends when `poison` is cancelled by a failed backfill
+        //    chunk. If it kept going instead, blocks above the tip would be
+        //    persisted while the failed chunk's blocks are missing — advancing
+        //    the stored height over a permanent gap. Ending the whole stream
+        //    hands the failure to the Reconnect Policy: the resubscribe
+        //    backfills again from the last stored block.
+        let live_source = Box::pin(
+            live_source
+                .filter(move |(block, _)| {
+                    let above_cut = *block > tip;
+                    async move { above_cut }
+                })
+                .take_until(poison.cancelled_owned()),
+        ) as CollectorStream<'_, (u64, E)>;
         let live = persist_and_emit(live_source, &self.store, self.schema.as_ref(), false);
 
         Ok(Segments {
@@ -219,6 +288,66 @@ where
     Ok(Box::pin(futures::stream::iter(events)))
 }
 
+/// Query the inclusive range `[from ..= to]` in block-aligned windows of at
+/// most `chunk` blocks, one `query_range` call at a time, flattened into a
+/// single stream.
+///
+/// The first window is queried eagerly so a backfill that can't start at all
+/// fails the subscribe (feeding the Reconnect Policy's counter). Later windows
+/// are queried lazily as the stream is consumed; one of them failing cannot
+/// fail the already-returned subscribe, so it instead logs, cancels `poison`,
+/// and ends the stream — every block delivered up to that point is complete,
+/// because windows are block-aligned.
+async fn chunked_query<'a, C, E>(
+    collector: &'a C,
+    from: u64,
+    to: u64,
+    chunk: u64,
+    poison: CancellationToken,
+) -> Result<CollectorStream<'a, (u64, E)>>
+where
+    C: PersistableCollector<E> + ?Sized,
+    E: Send + 'a,
+{
+    /// Last block of the window starting at `from`: `from + chunk - 1`,
+    /// saturating, and never beyond `to`.
+    fn window_end(from: u64, to: u64, chunk: u64) -> u64 {
+        from.saturating_add(chunk - 1).min(to)
+    }
+
+    let first_to = window_end(from, to, chunk);
+    let mut first = collector.query_range(from, first_to).await?;
+
+    let stream = async_stream::stream! {
+        while let Some(item) = first.next().await {
+            yield item;
+        }
+        let mut next_from = first_to.saturating_add(1);
+        // `saturating_add` can only stall at u64::MAX, where `window_end`
+        // already returned `to` and the loop is done.
+        while next_from <= to {
+            let next_to = window_end(next_from, to, chunk);
+            match collector.query_range(next_from, next_to).await {
+                Ok(mut window) => {
+                    while let Some(item) = window.next().await {
+                        yield item;
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "backfill chunk [{next_from}, {next_to}] failed; \
+                         ending stream for resubscribe: {e}"
+                    );
+                    poison.cancel();
+                    return;
+                }
+            }
+            next_from = next_to.saturating_add(1);
+        }
+    };
+    Ok(Box::pin(stream))
+}
+
 /// Wrap a stream of `(block, event)` so that each event is buffered and written
 /// to `store` one transaction per complete block, while the plain events flow
 /// downstream unchanged.
@@ -233,48 +362,103 @@ fn persist_and_emit<'a, E, S>(
     flush_final: bool,
 ) -> CollectorStream<'a, E>
 where
-    E: Serialize + SolEvent + Send + 'static,
+    E: Serialize + SolEvent + Send + Sync + 'static,
     S: Store + 'a,
 {
     let stream = async_stream::stream! {
-        let mut buffer: Vec<Row> = Vec::new();
-        let mut current: Option<u64> = None;
-        let mut schema: Option<TableSchema> = None;
-        // Once a write fails we stop persisting so `last_block` keeps pointing
-        // at a contiguous, gap-free prefix. The event stream itself keeps
-        // flowing; a restart re-fetches everything after the last good block.
-        let mut healthy = true;
+        let mut writer = BlockWriter::new(store, override_);
 
         while let Some((block, event)) = source.next().await {
-            match derive_record_with(&event, override_) {
-                Ok((row_schema, row)) => {
-                    // The block advanced: the previous block is complete.
-                    if healthy
-                        && let (Some(cur), Some(sch)) = (current, &schema)
-                        && block != cur
-                    {
-                        healthy = flush(store, sch, cur, std::mem::take(&mut buffer)).await;
-                    }
-                    current = Some(block);
-                    schema = Some(row_schema);
-                    buffer.push(row);
-                }
-                // A derive failure must not break the event stream the rest of
-                // the pipeline depends on; log and keep forwarding.
-                Err(e) => tracing::error!("failed to derive row for persistence: {e}"),
-            }
+            writer.record(block, &event).await;
             yield event;
         }
 
-        if healthy
-            && flush_final
-            && let (Some(cur), Some(sch)) = (current, &schema)
-        {
-            flush(store, sch, cur, std::mem::take(&mut buffer)).await;
+        if flush_final {
+            writer.finish().await;
         }
     };
 
     Box::pin(stream)
+}
+
+/// Buffers one block's rows at a time and writes each complete block to the
+/// store in a single transaction. A block is complete once a higher block
+/// number is observed; the trailing block is written only by [`finish`].
+///
+/// Once a write fails the writer goes unhealthy and stays that way: writing
+/// any later block would leave a hole behind `last_block`'s gap-free prefix.
+/// An unhealthy writer does no per-event work at all — deriving and buffering
+/// rows for blocks that will never be written would grow the buffer without
+/// bound on a live tail. The event stream itself keeps flowing either way; a
+/// restart re-fetches everything after the last good block.
+///
+/// [`finish`]: BlockWriter::finish
+struct BlockWriter<'a, S> {
+    store: &'a S,
+    override_: Option<&'a TableSchema>,
+    buffer: Vec<Row>,
+    current: Option<u64>,
+    schema: Option<TableSchema>,
+    healthy: bool,
+}
+
+impl<'a, S: Store> BlockWriter<'a, S> {
+    fn new(store: &'a S, override_: Option<&'a TableSchema>) -> Self {
+        Self {
+            store,
+            override_,
+            buffer: Vec::new(),
+            current: None,
+            schema: None,
+            healthy: true,
+        }
+    }
+
+    /// Buffer one event's row, first flushing the previous block if `block`
+    /// has advanced past it. No-op once unhealthy.
+    async fn record<E: Serialize + SolEvent>(&mut self, block: u64, event: &E) {
+        if !self.healthy {
+            return;
+        }
+        match derive_record_with(event, self.override_) {
+            Ok((row_schema, row)) => {
+                // The block advanced: the previous block is complete.
+                if let (Some(cur), Some(sch)) = (self.current, &self.schema)
+                    && block != cur
+                {
+                    self.healthy =
+                        flush(self.store, sch, cur, std::mem::take(&mut self.buffer)).await;
+                    if !self.healthy {
+                        // This event's block can never be written without
+                        // leaving a gap, so don't buffer its row either.
+                        return;
+                    }
+                }
+                self.current = Some(block);
+                self.schema = Some(row_schema);
+                self.buffer.push(row);
+            }
+            // A derive failure must not break the event stream the rest of
+            // the pipeline depends on; log and keep forwarding.
+            Err(e) => tracing::error!("failed to derive row for persistence: {e}"),
+        }
+    }
+
+    /// Flush the trailing block. Only correct when the source delivered the
+    /// block completely (a finite backfill range, not a live tail).
+    async fn finish(&mut self) {
+        if self.healthy
+            && let (Some(cur), Some(sch)) = (self.current, &self.schema)
+        {
+            flush(self.store, sch, cur, std::mem::take(&mut self.buffer)).await;
+        }
+    }
+
+    /// Rows currently buffered for the open block.
+    #[cfg(test)]
+    fn buffered(&self) -> usize {
+        self.buffer.len()
+    }
 }
 
 /// Persist one block's buffered rows. Returns `false` (and logs) on failure so
@@ -287,5 +471,74 @@ async fn flush<S: Store>(store: &S, schema: &TableSchema, block: u64, rows: Vec<
             tracing::error!("failed to persist block {block}; halting persistence: {e}");
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    alloy::sol! {
+        #[derive(serde::Serialize)]
+        event Ping(uint256 value);
+    }
+
+    fn ping(value: u64) -> Ping {
+        Ping {
+            value: alloy::primitives::U256::from(value),
+        }
+    }
+
+    /// A store whose every write fails.
+    struct FailingStore;
+
+    #[async_trait]
+    impl Store for FailingStore {
+        async fn write_block(
+            &self,
+            _schema: &TableSchema,
+            block: u64,
+            _rows: Vec<Row>,
+        ) -> Result<()> {
+            anyhow::bail!("simulated write failure at block {block}")
+        }
+        async fn last_block(&self, _table: &str) -> Result<Option<u64>> {
+            Ok(None)
+        }
+        async fn replay(&self, _schema: &TableSchema, _to: u64) -> Result<Vec<Row>> {
+            Ok(vec![])
+        }
+    }
+
+    /// Once a write fails, persistence is halted for the rest of the stream —
+    /// and a halted writer must stop doing per-event work entirely. Deriving
+    /// and buffering rows for blocks that will never be written would grow the
+    /// buffer without bound on a live tail: one transient write failure would
+    /// become a slow-motion OOM.
+    #[tokio::test]
+    async fn writer_stops_buffering_once_unhealthy() {
+        let store = FailingStore;
+        let mut writer = BlockWriter::new(&store, None);
+
+        // Block 1 buffers normally.
+        writer.record(1, &ping(1)).await;
+        assert_eq!(writer.buffered(), 1);
+
+        // Block 2 arrives: block 1 is complete, its flush fails, and the
+        // writer goes unhealthy. Block 2's row must not be buffered either —
+        // its block can never be written without leaving a gap.
+        writer.record(2, &ping(2)).await;
+        assert_eq!(writer.buffered(), 0, "failed flush must clear the buffer");
+
+        // A long tail of further events must not accumulate anything.
+        for block in 3..100 {
+            writer.record(block, &ping(block)).await;
+        }
+        assert_eq!(
+            writer.buffered(),
+            0,
+            "an unhealthy writer must not accumulate rows"
+        );
     }
 }

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -68,6 +68,12 @@ struct FakeCollector {
     /// Number of leading `query_range` calls that should error before the rest
     /// succeed — used to simulate a transient RPC backfill failure.
     query_range_fails: AtomicUsize,
+    /// 1-based index of a single `query_range` call to fail (0 = none) — used
+    /// to simulate one bad chunk in the middle of a sliced backfill.
+    query_range_fails_on_call: AtomicUsize,
+    /// Every `(from, to)` range passed to `query_range`, for asserting how the
+    /// wrapper slices the backfill.
+    queried: Arc<std::sync::Mutex<Vec<(u64, u64)>>>,
 }
 
 impl FakeCollector {
@@ -86,6 +92,15 @@ impl FakeCollector {
     fn fail_query_range_times(self, n: usize) -> Self {
         self.query_range_fails.store(n, Ordering::SeqCst);
         self
+    }
+    fn fail_query_range_on_call(self, n: usize) -> Self {
+        self.query_range_fails_on_call.store(n, Ordering::SeqCst);
+        self
+    }
+    /// Handle onto the recorded `query_range` calls; stays usable after the
+    /// collector has been consumed by `with_persistence`.
+    fn queried(&self) -> Arc<std::sync::Mutex<Vec<(u64, u64)>>> {
+        self.queried.clone()
     }
 }
 
@@ -111,6 +126,19 @@ impl PersistableCollector<ValueSet> for FakeCollector {
         from: u64,
         to: u64,
     ) -> Result<CollectorStream<'_, (u64, ValueSet)>> {
+        let call_number = {
+            let mut queried = self.queried.lock().unwrap();
+            queried.push((from, to));
+            queried.len()
+        };
+        // Real RPC providers reject inverted `eth_getLogs` ranges; tolerating
+        // them here would hide a wrapper that issues impossible queries.
+        if from > to {
+            anyhow::bail!("inverted range: from {from} > to {to}");
+        }
+        if self.query_range_fails_on_call.load(Ordering::SeqCst) == call_number {
+            anyhow::bail!("simulated query_range failure on call {call_number}");
+        }
         let remaining = self.query_range_fails.load(Ordering::SeqCst);
         if remaining > 0 {
             self.query_range_fails
@@ -413,6 +441,152 @@ async fn persisted_backfills_gap_between_last_stored_and_tip() {
     );
 }
 
+/// Restarting while the stored height already equals (or exceeds) the chain
+/// tip must not issue an inverted backfill query (`from > to`). Real providers
+/// reject inverted `eth_getLogs` ranges, and that error would fail every
+/// resubscribe until the Reconnect Policy escalates to Fatal — a restart brick
+/// whose occurrence depends on restart timing. There is no gap, so no query
+/// should be issued at all.
+#[tokio::test]
+async fn backfill_is_skipped_when_store_is_at_the_tip() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+    seed(&store, 6, 1).await; // last stored block = 6
+
+    // The chain tip is *also* 6 — a restart within one block interval.
+    let collector = FakeCollector::default().live(vec![(7, 2)]).tip(6);
+    let queried = collector.queried();
+    let persisted = collector.with_persistence(store.clone());
+
+    let events: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+
+    // Replay delivers the archive, live carries on; nothing was backfilled.
+    assert_eq!(events, vec![value_event(1), value_event(2)]);
+    assert_eq!(
+        *queried.lock().unwrap(),
+        Vec::<(u64, u64)>::new(),
+        "no backfill query should be issued when there is no gap"
+    );
+}
+
+/// The backfill must be sliced into bounded windows rather than issued as one
+/// `query_range` over the whole gap. With an empty store the gap is the entire
+/// chain (`[0 ..= tip]`); a single `eth_getLogs` over that is rejected by most
+/// providers (range/result caps) or returns an unboundedly large payload.
+#[tokio::test]
+async fn backfill_is_sliced_into_bounded_chunks() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+
+    let collector = FakeCollector::default()
+        .tip(25)
+        .backfill(vec![(5, 1), (15, 2), (25, 3)])
+        .live(vec![(26, 4)]);
+    let queried = collector.queried();
+    let persisted = collector
+        .with_persistence(store.clone())
+        .with_backfill_chunk_size(10);
+
+    let events: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+
+    // Every backfilled event arrives, in block order, then the live tail.
+    assert_eq!(
+        events,
+        vec![
+            value_event(1),
+            value_event(2),
+            value_event(3),
+            value_event(4)
+        ]
+    );
+    // The gap was queried in inclusive, block-aligned windows of 10.
+    assert_eq!(*queried.lock().unwrap(), vec![(0, 9), (10, 19), (20, 25)]);
+    // Backfilled blocks are complete, so the trailing one is flushed too.
+    assert_eq!(store.last_block("value_set").await.unwrap(), Some(25));
+}
+
+/// With an empty store, the Backfill segment must begin at the configured
+/// start block instead of genesis — a strategy that only cares about recent
+/// history shouldn't have to sync (or be able to fetch) the whole chain.
+#[tokio::test]
+async fn backfill_starts_at_the_configured_start_block() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+
+    // An event below the start block must never be queried for.
+    let collector = FakeCollector::default()
+        .tip(125)
+        .backfill(vec![(99, 1), (110, 2)]);
+    let queried = collector.queried();
+    let persisted = collector
+        .with_persistence(store.clone())
+        .with_start_block(100);
+
+    let events: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+
+    assert_eq!(events, vec![value_event(2)]);
+    assert_eq!(*queried.lock().unwrap(), vec![(100, 125)]);
+}
+
+/// Stored history that already reaches beyond the start block wins: the
+/// Backfill segment resumes from the last stored block, not from the start
+/// block, so no stored range is ever re-fetched.
+#[tokio::test]
+async fn stored_history_beyond_the_start_block_wins() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+    seed(&store, 110, 1).await; // last stored block = 110
+
+    let collector = FakeCollector::default()
+        .tip(125)
+        .backfill(vec![(105, 9), (115, 2)]);
+    let queried = collector.queried();
+    let persisted = collector
+        .with_persistence(store.clone())
+        .with_start_block(100);
+
+    let events: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
+
+    // Replay delivers the archive; backfill covers only `[111 ..= 125]`.
+    assert_eq!(events, vec![value_event(1), value_event(2)]);
+    assert_eq!(*queried.lock().unwrap(), vec![(111, 125)]);
+}
+
+/// A chunk failure in the middle of the Backfill segment must end the whole
+/// subscription stream — including the live tail — not just the backfill. If
+/// the live tail kept going, blocks above the tip would be persisted while the
+/// failed chunk's blocks are missing, advancing the stored height over a
+/// permanent gap. Ending the stream instead hands the failure to the Reconnect
+/// Policy: the resubscribe backfills again from the last stored block.
+#[tokio::test]
+async fn mid_backfill_chunk_failure_ends_the_stream_without_corrupting_progress() {
+    let store = Arc::new(SqliteStore::connect("sqlite::memory:").await.unwrap());
+
+    let collector = FakeCollector::default()
+        .tip(25)
+        .backfill(vec![(5, 1), (15, 2), (25, 3)])
+        .live(vec![(26, 4)])
+        .fail_query_range_on_call(2); // the second chunk
+    let persisted = collector
+        .with_persistence(store.clone())
+        .with_backfill_chunk_size(10);
+
+    // The first chunk is queried eagerly and is fine, so subscribe succeeds.
+    let stream = persisted.subscribe().await.unwrap();
+
+    // The stream must terminate (bounded by the timeout) after delivering only
+    // the first chunk — no later chunks, and crucially no live events.
+    let events: Vec<ValueSet> =
+        tokio::time::timeout(std::time::Duration::from_secs(5), stream.collect())
+            .await
+            .expect("stream must end after a failed backfill chunk");
+    assert_eq!(
+        events,
+        vec![value_event(1)],
+        "no event past the failed chunk may be delivered"
+    );
+
+    // The complete first chunk was flushed; nothing later advanced progress.
+    assert_eq!(store.last_block("value_set").await.unwrap(), Some(5));
+    assert_eq!(stored_values(&store).await, vec!["0x1".to_string()]);
+}
+
 /// Slice 5: a schema override declared on the Persisted Collector changes the
 /// table name and column types; events persist under the overridden table.
 #[tokio::test]
@@ -546,10 +720,12 @@ async fn failed_subscribe_does_not_consume_replay() {
     seed(&store, 5, 1).await;
     seed(&store, 6, 2).await;
 
-    // The first backfill query errors; subsequent ones succeed.
+    // Tip 7 leaves a one-block gap, so a backfill query is issued; the first
+    // one errors, subsequent ones succeed.
     let collector = FakeCollector::default()
-        .live(vec![(7, 3)])
-        .tip(6)
+        .backfill(vec![(7, 3)])
+        .live(vec![(8, 4)])
+        .tip(7)
         .fail_query_range_times(1);
     let persisted = collector.with_persistence(store.clone());
 
@@ -562,7 +738,15 @@ async fn failed_subscribe_does_not_consume_replay() {
     // Retry: the stored history (1, 2) must still be replayed — the failed
     // attempt must not have flipped the replay-once flag.
     let events: Vec<ValueSet> = persisted.subscribe().await.unwrap().collect().await;
-    assert_eq!(events, vec![value_event(1), value_event(2), value_event(3)]);
+    assert_eq!(
+        events,
+        vec![
+            value_event(1),
+            value_event(2),
+            value_event(3),
+            value_event(4)
+        ]
+    );
 }
 
 /// A store that fails `write_block` for one specific block, delegating


### PR DESCRIPTION
Three hardening fixes for the persistence layer, each with regression tests:

1. Halted persistence no longer buffers (slow-motion OOM). After a failed block write, persist_and_emit kept deriving and buffering a row for every subsequent event on a never-ending live tail — unbounded memory growth from one transient write failure. The per-block buffering state machine is now an extracted BlockWriter that does no per-event work once unhealthy.

2. No inverted backfill query when the store is at the tip. Restarting within one block interval made subscribe call query_range(tip+1, tip); real providers reject inverted eth_getLogs ranges, failing every resubscribe until the Reconnect Policy escalated to Fatal — a timing-dependent restart brick. With no gap, no query is issued. The FakeCollector now rejects inverted ranges like real providers do, which also caught three existing tests silently relying on the old tolerance.

3. The backfill is sliced into bounded chunks with a configurable start block. An empty store used to backfill with a single eth_getLogs(0, tip) — rejected by most providers' range caps, or an unbounded in-memory payload. The gap is now queried in block-aligned windows (default 10k blocks, .with_backfill_chunk_size(..)), and .with_start_block(..) sets where the very first sync begins instead of genesis. The first window is queried eagerly so a backfill that can't start still fails the subscribe; a later window failing cancels a poison token that ends the live tail too — otherwise blocks above the tip would be persisted while the failed chunk's blocks are missing, advancing the stored height over a permanent gap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core persistence subscribe/backfill and store progress semantics; mistakes could cause gaps, missed events, or reconnect loops, but behavior is heavily regression-tested.
> 
> **Overview**
> Hardens **`Persisted`** backfill and block persistence for real RPC providers and failure modes.
> 
> **Backfill behavior:** Adds `.with_start_block(..)` and `.with_backfill_chunk_size(..)` (default 10k blocks) so the gap is queried in block-aligned windows instead of one `eth_getLogs(0, tip)`. Skips `query_range` when there is no gap (`backfill_from > tip`), avoiding inverted ranges that brick resubscribes. Mid-backfill chunk failures cancel a `poison` token so the live tail stops too—stored height cannot advance past a missing chunk.
> 
> **Writes:** Refactors per-block buffering into **`BlockWriter`**, which stops deriving/buffering after a failed flush (fixes unbounded memory growth on a long live tail after one bad write).
> 
> Docs (`README`, `CONTEXT`) and integration tests cover chunking, start block, skip-at-tip, mid-chunk failure, and inverted-range rejection in `FakeCollector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1831957ba01f052ce5500628c3417ad17f57e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->