### PR TITLE
Fix/medium severity hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.6"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbff8445282ec080c2673692062bd4930d7a0d6bda257caf138cfc650c503000"
+checksum = "3165210652f71dfc094b051602bafd691f506c54050a174b1cba18fb5ef706a3"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c4a039f33025c4f4a88c121ce59f0b09a7ec159ac76c843dfb96a663cc48e8"
+checksum = "eec6d2e7743d2bcb3e7dfc9cb7a7322bc0f808fddd48f4aab5d974260f2ae0cf"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -1497,9 +1497,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,12 @@ edition = "2024"
 ## async
 async-trait = "0.1"
 futures = "0.3"
-tokio = { version = "1.44", features = ["full"] }
+## The library itself needs only these; downstream binaries pick their own
+## runtime flavour (`rt-multi-thread`, `signal`, ...).
+tokio = { version = "1.44", features = ["rt", "sync", "time", "macros"] }
 tokio-stream = { version = "0.1", features = ['sync'] }
 tokio-util = "0.7"
-alloy = { version = "1.0", features = [
-    "full",
-    "node-bindings",
-] }
+alloy = { version = "1.0", features = ["full"] }
 ## persistence
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -29,6 +28,9 @@ tracing = "0.1.41"
 ## `test-util` enables `tokio::time::pause`/`start_paused` so the collector
 ## driver's backoff timing can be asserted on virtual time.
 tokio = { version = "1.44", features = ["full", "test-util"] }
+## `node-bindings` (Anvil process spawning) is test/example tooling only; it
+## must not ship to downstream consumers of the library.
+alloy = { version = "1.0", features = ["node-bindings"] }
 
 [[example]]
 name = "basic_example"

--- a/src/collectors/event_collector.rs
+++ b/src/collectors/event_collector.rs
@@ -17,6 +17,29 @@ impl<P, E> EventCollector<P, E> {
     }
 }
 
+/// The `(block, event)` to deliver for one decoded log, or `None` to skip it.
+///
+/// A log re-sent with `removed: true` is a reorg *retraction*: the node is
+/// telling us the event no longer happened. Delivering it as a fresh event
+/// would hand strategies a second occurrence — and persist a duplicate row
+/// that replays forever after. A log with no block number cannot be indexed.
+fn indexed_event<E>(event: E, log: &alloy::rpc::types::Log) -> Option<(u64, E)> {
+    if log.removed {
+        tracing::warn!(
+            block = log.block_number,
+            "skipping reorged (removed) event log"
+        );
+        return None;
+    }
+    match log.block_number {
+        Some(block) => Some((block, event)),
+        None => {
+            tracing::warn!("Event log missing block number; skipping");
+            None
+        }
+    }
+}
+
 /// Implementation of the [Collector](Collector) trait for the [EventCollector](EventCollector).
 #[async_trait]
 impl<P, E> Collector<E> for EventCollector<P, E>
@@ -27,7 +50,7 @@ where
     async fn subscribe(&self) -> Result<CollectorStream<'_, E>> {
         let stream = self.event.subscribe().await?.into_stream();
         let stream = stream.filter_map(|el| match el {
-            Ok((e, _)) => Some(e),
+            Ok((e, log)) => indexed_event(e, &log).map(|(_, e)| e),
             Err(e) => {
                 tracing::warn!("Failed to decode event log: {}", e);
                 None
@@ -49,13 +72,7 @@ where
     async fn subscribe_indexed(&self) -> Result<CollectorStream<'_, (u64, E)>> {
         let stream = self.event.subscribe().await?.into_stream();
         let stream = stream.filter_map(|el| match el {
-            Ok((event, log)) => match log.block_number {
-                Some(block) => Some((block, event)),
-                None => {
-                    tracing::warn!("Event log missing block number; skipping");
-                    None
-                }
-            },
+            Ok((event, log)) => indexed_event(event, &log),
             Err(e) => {
                 tracing::warn!("Failed to decode event log: {}", e);
                 None
@@ -74,12 +91,43 @@ where
             .query()
             .await?
             .into_iter()
-            .filter_map(|(event, log)| log.block_number.map(|block| (block, event)))
+            .filter_map(|(event, log)| indexed_event(event, &log))
             .collect();
         Ok(Box::pin(tokio_stream::iter(events)))
     }
 
     async fn tip(&self) -> Result<u64> {
         Ok(self.event.provider.get_block_number().await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::rpc::types::Log;
+
+    fn log_at(block: Option<u64>, removed: bool) -> Log {
+        Log {
+            block_number: block,
+            removed,
+            ..Default::default()
+        }
+    }
+
+    /// On a reorg, nodes re-send previously delivered logs with
+    /// `removed: true` to signal *retraction*. Treating one as a fresh event
+    /// would hand strategies a second occurrence of something that no longer
+    /// happened — and persist a duplicate row that replays forever after.
+    #[test]
+    fn removed_logs_are_retractions_not_events() {
+        assert_eq!(indexed_event((), &log_at(Some(5), true)), None);
+    }
+
+    /// A live log carries its block number through; one with no block number
+    /// cannot be indexed and is skipped.
+    #[test]
+    fn live_logs_carry_their_block_number() {
+        assert_eq!(indexed_event((), &log_at(Some(5), false)), Some((5, ())));
+        assert_eq!(indexed_event((), &log_at(None, false)), None);
     }
 }

--- a/src/executors/mempool_executor.rs
+++ b/src/executors/mempool_executor.rs
@@ -41,7 +41,9 @@ pub struct GasBidInfo {
     /// Total profit expected from opportunity
     pub total_profit: u128,
 
-    /// Percentage of bid profit to use for gas
+    /// Percentage of bid profit to use for gas, at most 100: bidding the whole
+    /// profit (100) breaks even; anything above it makes the transaction
+    /// itself the loss, so the executor refuses such actions.
     pub bid_percentage: u64,
 }
 
@@ -58,6 +60,19 @@ where
 {
     /// Send a transaction to the mempool.
     async fn execute(&mut self, mut action: SubmitTxToMempool) -> Result<()> {
+        // Refuse an over-100% bid before spending any RPC on it: it would
+        // price gas above the opportunity's total profit, making the
+        // transaction itself the loss.
+        if let Some(gas_bid_info) = &action.gas_bid_info
+            && gas_bid_info.bid_percentage > 100
+        {
+            return Err(anyhow::anyhow!(
+                "bid_percentage {} exceeds 100: the gas bid would cost more \
+                 than the opportunity's total profit",
+                gas_bid_info.bid_percentage
+            ));
+        }
+
         let gas_usage = tokio::time::timeout(
             self.rpc_timeout,
             self.client.estimate_gas(action.tx.clone()),
@@ -85,6 +100,10 @@ where
                 .context("Timeout getting gas price")?
                 .context("Error getting gas price")?;
         }
+        // The estimate priced the bid; set it as the limit too, so the
+        // provider's filler doesn't estimate a second time (an extra RPC per
+        // action, and a limit that could diverge from the one priced).
+        action.tx.set_gas_limit(gas_usage);
         action.tx.set_gas_price(bid_gas_price);
         let _pending_tx =
             tokio::time::timeout(self.rpc_timeout, self.client.send_transaction(action.tx))

--- a/src/persistence/persisted.rs
+++ b/src/persistence/persisted.rs
@@ -11,8 +11,8 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio_util::sync::CancellationToken;
 
-use super::record::{PAYLOAD_COLUMN, derive_record_with, from_payload, table_name};
-use super::schema::{Row, SqlType, SqlValue, TableSchema};
+use super::record::{derive_record_with, from_payload, table_name};
+use super::schema::{PAYLOAD_COLUMN, Row, SqlType, SqlValue, TableSchema};
 use super::store::Store;
 use crate::types::{Collector, CollectorStream};
 
@@ -89,7 +89,16 @@ impl<C, S> Persisted<C, S> {
     /// from the event signature: rows go to `schema`'s table with its listed
     /// columns (event fields it does not list are dropped; the lossless
     /// payload column is always appended).
+    ///
+    /// # Panics
+    /// Panics when the schema names a column the persistence layer adds
+    /// implicitly (`block_number`, `_payload`) or the store's internal
+    /// progress table — misconfigurations that would otherwise halt
+    /// persistence with an opaque SQL error on the first write.
     pub fn with_schema(mut self, schema: TableSchema) -> Self {
+        if let Err(reason) = schema.ensure_no_reserved_names() {
+            panic!("invalid schema override: {reason}");
+        }
         self.schema = Some(schema);
         self
     }
@@ -431,26 +440,52 @@ impl<'a, S: Store> BlockWriter<'a, S> {
         }
         match derive_record_with(event, self.override_) {
             Ok((row_schema, row)) => {
-                // The block advanced: the previous block is complete.
-                if let (Some(cur), Some(sch)) = (self.current, &self.schema)
-                    && block != cur
-                {
-                    self.healthy =
-                        flush(self.store, sch, cur, std::mem::take(&mut self.buffer)).await;
-                    if !self.healthy {
-                        // This event's block can never be written without
-                        // leaving a gap, so don't buffer its row either.
+                if let (Some(cur), Some(sch)) = (self.current, &self.schema) {
+                    // A backwards block means the open block's completeness
+                    // can no longer be trusted: flushing it would advance the
+                    // stored height past the late block's rows, leaving a
+                    // permanent hole behind the gap-free watermark.
+                    if block < cur {
+                        self.halt(format_args!(
+                            "block {block} arrived after block {cur} (reorg or \
+                             unordered source)"
+                        ));
                         return;
+                    }
+                    // The block advanced: the previous block is complete.
+                    if block > cur {
+                        self.healthy =
+                            flush(self.store, sch, cur, std::mem::take(&mut self.buffer)).await;
+                        if !self.healthy {
+                            // This event's block can never be written without
+                            // leaving a gap, so don't buffer its row either.
+                            return;
+                        }
                     }
                 }
                 self.current = Some(block);
                 self.schema = Some(row_schema);
                 self.buffer.push(row);
             }
-            // A derive failure must not break the event stream the rest of
-            // the pipeline depends on; log and keep forwarding.
-            Err(e) => tracing::error!("failed to derive row for persistence: {e}"),
+            // An event that can't be derived into a row can never be written,
+            // so its block — and everything after it — must not be either:
+            // progress advancing past it would hand the next restart exactly
+            // the quietly truncated history `replay_stored` refuses to emit.
+            // The event stream itself keeps flowing.
+            Err(e) => self.halt(format_args!("failed to derive row: {e}")),
         }
+    }
+
+    /// Stop persisting for the rest of the stream and discard the open block's
+    /// buffer (its completeness is no longer trustworthy). The stored height
+    /// stays at the last fully written block; a restart re-fetches from there.
+    fn halt(&mut self, reason: std::fmt::Arguments<'_>) {
+        self.healthy = false;
+        self.buffer.clear();
+        tracing::error!(
+            "halting persistence ({reason}); events keep flowing, and a \
+             restart will re-sync from the last stored block"
+        );
     }
 
     /// Flush the trailing block. Only correct when the source delivered the
@@ -499,6 +534,18 @@ mod tests {
         }
     }
 
+    alloy::sol! {
+        // No serde derive: `Serialize` is implemented by hand below to produce
+        // a non-object JSON value, which `derive_record_with` rejects.
+        event BadPing(uint256 value);
+    }
+
+    impl serde::Serialize for BadPing {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_str("not a JSON object")
+        }
+    }
+
     /// A store whose every write fails.
     struct FailingStore;
 
@@ -511,6 +558,37 @@ mod tests {
             _rows: Vec<Row>,
         ) -> Result<()> {
             anyhow::bail!("simulated write failure at block {block}")
+        }
+        async fn last_block(&self, _table: &str) -> Result<Option<u64>> {
+            Ok(None)
+        }
+        async fn replay(&self, _schema: &TableSchema, _to: u64) -> Result<Vec<Row>> {
+            Ok(vec![])
+        }
+    }
+
+    /// A store that records which blocks were written and always succeeds.
+    #[derive(Default)]
+    struct RecordingStore {
+        written: std::sync::Mutex<Vec<u64>>,
+    }
+
+    impl RecordingStore {
+        fn written(&self) -> Vec<u64> {
+            self.written.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl Store for RecordingStore {
+        async fn write_block(
+            &self,
+            _schema: &TableSchema,
+            block: u64,
+            _rows: Vec<Row>,
+        ) -> Result<()> {
+            self.written.lock().unwrap().push(block);
+            Ok(())
         }
         async fn last_block(&self, _table: &str) -> Result<Option<u64>> {
             Ok(None)
@@ -549,5 +627,60 @@ mod tests {
             0,
             "an unhealthy writer must not accumulate rows"
         );
+    }
+
+    /// A live stream can deliver a lower block after a higher one (a reorg
+    /// re-emission, or a misbehaving source). Flushing on *any* block change
+    /// would write the higher block — advancing `_artemis_progress` past the
+    /// lower block whose rows were never written, so a crash between the two
+    /// transactions leaves a permanent hole behind a "gap-free" watermark. A
+    /// backwards block must instead halt the writer before anything is
+    /// written: the open block's completeness can no longer be trusted.
+    #[tokio::test]
+    async fn writer_halts_on_non_monotone_blocks_without_writing() {
+        let store = RecordingStore::default();
+        let mut writer = BlockWriter::new(&store, None);
+
+        writer.record(5, &ping(1)).await;
+        writer.record(4, &ping(2)).await; // block went backwards
+        writer.record(5, &ping(3)).await; // the reorg's second half
+        writer.finish().await;
+
+        assert_eq!(
+            store.written(),
+            Vec::<u64>::new(),
+            "no block may be written once ordering is violated"
+        );
+        assert_eq!(writer.buffered(), 0);
+    }
+
+    /// An event that cannot be derived into a row must halt persistence, not
+    /// be skipped: progress would otherwise advance past its block, and replay
+    /// would hand strategies exactly the "quietly truncated history" the read
+    /// side refuses to produce (see `replay_stored`). Strategies that ran live
+    /// saw the event; strategies after a restart must not silently lose it.
+    #[tokio::test]
+    async fn writer_halts_on_underivable_event_instead_of_leaving_a_hole() {
+        let store = RecordingStore::default();
+        let mut writer = BlockWriter::new(&store, None);
+
+        writer.record(1, &ping(1)).await;
+        writer
+            .record(
+                2,
+                &BadPing {
+                    value: alloy::primitives::U256::ZERO,
+                },
+            )
+            .await;
+        writer.record(3, &ping(3)).await; // would previously flush past block 2
+        writer.finish().await;
+
+        assert_eq!(
+            store.written(),
+            Vec::<u64>::new(),
+            "nothing may be written once an event cannot be persisted"
+        );
+        assert_eq!(writer.buffered(), 0);
     }
 }

--- a/src/persistence/record.rs
+++ b/src/persistence/record.rs
@@ -12,11 +12,9 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
-use super::schema::{Column, Row, SqlType, SqlValue, TableSchema};
-
-/// Name of the implicit column holding each event's full JSON, used to
-/// losslessly reconstruct the event when replaying from the database.
-pub const PAYLOAD_COLUMN: &str = "_payload";
+use super::schema::{
+    BLOCK_NUMBER_COLUMN, Column, PAYLOAD_COLUMN, Row, SqlType, SqlValue, TableSchema,
+};
 
 /// The best-guess table name for an event type, derived from its Solidity
 /// signature: `ValueSet(uint256)` -> `value_set`.
@@ -91,6 +89,12 @@ where
 
     let (table, columns, mut values) = match override_ {
         Some(schema) => {
+            // An override colliding with an implicit column would produce a
+            // `CREATE TABLE` with duplicate columns; surfacing it here makes
+            // the failure a clear derive error rather than an opaque SQL one.
+            if let Err(reason) = schema.ensure_no_reserved_names() {
+                anyhow::bail!("invalid schema override: {reason}");
+            }
             let values = schema
                 .columns
                 .iter()
@@ -107,6 +111,16 @@ where
             let mut columns = Vec::with_capacity(fields.len());
             let mut values = Vec::with_capacity(fields.len());
             for (name, (ty, value)) in &fields {
+                // The store adds BLOCK_NUMBER_COLUMN and this fn appends
+                // PAYLOAD_COLUMN; an event field by either name would shadow
+                // them in `CREATE TABLE` and break every write.
+                if name == BLOCK_NUMBER_COLUMN || name == PAYLOAD_COLUMN {
+                    anyhow::bail!(
+                        "event field {name:?} is reserved for an implicit column \
+                         the persistence layer adds to every table; rename it \
+                         with a schema override"
+                    );
+                }
                 columns.push(Column::new(name.clone(), *ty));
                 values.push(value.clone());
             }
@@ -140,7 +154,13 @@ pub fn from_payload<E: DeserializeOwned>(payload: &str) -> Result<E> {
 fn infer_type(value: &Value) -> SqlType {
     match value {
         Value::Bool(_) => SqlType::Integer,
-        Value::Number(n) if n.is_i64() || n.is_u64() => SqlType::Integer,
+        Value::Number(n) if n.is_i64() => SqlType::Integer,
+        // A u64 beyond i64::MAX exceeds SQLite's signed 64-bit integers; it is
+        // stored as decimal text (see `json_to_sql`), so type it as text.
+        Value::Number(n) if n.is_u64() => match n.as_u64() {
+            Some(u) if u > i64::MAX as u64 => SqlType::Text,
+            _ => SqlType::Integer,
+        },
         Value::Number(_) => SqlType::Real,
         Value::String(_) => SqlType::Text,
         // Arrays, objects and null are stored as JSON text.
@@ -157,7 +177,11 @@ fn json_to_sql(value: &Value) -> SqlValue {
             if let Some(i) = n.as_i64() {
                 SqlValue::Integer(i)
             } else if let Some(u) = n.as_u64() {
-                SqlValue::Integer(u as i64)
+                // Beyond SQLite's signed 64-bit integers: reinterpreting via
+                // `as i64` would store u64::MAX as -1, handing SQL queries
+                // silently wrong numbers. Spill to decimal text instead; the
+                // `_payload` column already preserves the exact value.
+                SqlValue::Text(u.to_string())
             } else {
                 SqlValue::Real(n.as_f64().unwrap_or(0.0))
             }
@@ -206,7 +230,8 @@ mod tests {
     fn infer_type_is_a_best_guess_from_json() {
         assert_eq!(infer_type(&json!(true)), SqlType::Integer);
         assert_eq!(infer_type(&json!(7)), SqlType::Integer);
-        assert_eq!(infer_type(&json!(u64::MAX)), SqlType::Integer);
+        // Too large for SQLite's signed 64-bit integers: stored as text.
+        assert_eq!(infer_type(&json!(u64::MAX)), SqlType::Text);
         assert_eq!(infer_type(&json!(1.5)), SqlType::Real);
         assert_eq!(infer_type(&json!("0x2a")), SqlType::Text);
         // Arrays, objects and null fall back to JSON text.
@@ -229,13 +254,18 @@ mod tests {
     }
 
     #[test]
-    fn json_to_sql_keeps_a_u64_above_i64_max_as_integer() {
-        // u64::MAX does not fit in i64; it is reinterpreted via `as i64` rather
-        // than spilling to Real, matching SQLite's 64-bit integer storage.
+    fn json_to_sql_spills_a_u64_above_i64_max_to_decimal_text() {
+        // SQLite integers are signed 64-bit; reinterpreting via `as i64` would
+        // store u64::MAX as -1, handing SQL queries silently wrong numbers
+        // (the `_payload` column preserves the true value, so replay was never
+        // affected — but queryable columns must not lie). Spill to a decimal
+        // string instead.
         let big = u64::MAX;
+        assert_eq!(json_to_sql(&json!(big)), SqlValue::Text(big.to_string()));
+        // The i64 boundary itself still fits and stays an integer.
         assert_eq!(
-            json_to_sql(&json!(big)),
-            SqlValue::Integer(big as i64) // == -1
+            json_to_sql(&json!(i64::MAX as u64)),
+            SqlValue::Integer(i64::MAX)
         );
     }
 

--- a/src/persistence/schema.rs
+++ b/src/persistence/schema.rs
@@ -1,5 +1,17 @@
 //! Table schema and row value types shared by every [`Store`](super::Store).
 
+/// Name of the implicit per-row block column every [`Store`](super::Store)
+/// adds when writing.
+pub(crate) const BLOCK_NUMBER_COLUMN: &str = "block_number";
+
+/// Name of the implicit column holding each event's full JSON, used to
+/// losslessly reconstruct the event when replaying from the database.
+pub const PAYLOAD_COLUMN: &str = "_payload";
+
+/// Name of the bookkeeping table [`SqliteStore`](super::SqliteStore) records
+/// per-table progress in.
+pub(crate) const PROGRESS_TABLE: &str = "_artemis_progress";
+
 /// A SQL column type. SQLite is dynamically typed, so these act as type
 /// affinities / a best-guess mapping from event field types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -62,6 +74,29 @@ impl TableSchema {
     pub fn col(mut self, name: impl Into<String>, ty: SqlType) -> Self {
         self.columns.push(Column::new(name, ty));
         self
+    }
+
+    /// Err when the schema collides with identifiers the persistence layer
+    /// itself uses: the implicit [`BLOCK_NUMBER_COLUMN`] and [`PAYLOAD_COLUMN`]
+    /// columns (a collision produces a `CREATE TABLE` with duplicate columns),
+    /// or the internal [`PROGRESS_TABLE`] (a collision corrupts every table's
+    /// progress watermark).
+    pub(crate) fn ensure_no_reserved_names(&self) -> Result<(), String> {
+        if self.table == PROGRESS_TABLE {
+            return Err(format!(
+                "table name {PROGRESS_TABLE:?} is reserved for the store's internal bookkeeping"
+            ));
+        }
+        for column in &self.columns {
+            if column.name == BLOCK_NUMBER_COLUMN || column.name == PAYLOAD_COLUMN {
+                return Err(format!(
+                    "column name {:?} is reserved for an implicit column the \
+                     persistence layer adds to every table",
+                    column.name
+                ));
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/persistence/sqlite.rs
+++ b/src/persistence/sqlite.rs
@@ -1,13 +1,17 @@
 //! A [`Store`] backed by SQLite via `sqlx`.
 
 use std::str::FromStr;
+use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions, SqliteRow};
+use sqlx::sqlite::{
+    SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow,
+    SqliteSynchronous,
+};
 use sqlx::{Arguments, Row as _, sqlite::SqliteArguments};
 
-use super::schema::{Row, SqlType, SqlValue, TableSchema};
+use super::schema::{BLOCK_NUMBER_COLUMN, PROGRESS_TABLE, Row, SqlType, SqlValue, TableSchema};
 use super::store::Store;
 
 /// A SQLite-backed [`Store`].
@@ -21,8 +25,19 @@ impl SqliteStore {
     /// Use `"sqlite::memory:"` for an ephemeral in-memory database. A single
     /// connection is used so an in-memory database is shared across calls and
     /// every write sees a consistent view.
+    ///
+    /// File databases run in WAL journal mode with `synchronous = NORMAL` and
+    /// a 5s busy timeout: the default rollback journal answers any concurrent
+    /// access with an immediate `SQLITE_BUSY`, and a single failed write
+    /// permanently halts persistence (by design, to keep the stored height a
+    /// gap-free prefix) — so a stray reader must wait, not kill the archive.
+    /// In-memory databases ignore the journal mode.
     pub async fn connect(url: &str) -> Result<Self> {
-        let opts = SqliteConnectOptions::from_str(url)?.create_if_missing(true);
+        let opts = SqliteConnectOptions::from_str(url)?
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
+            .busy_timeout(Duration::from_secs(5));
         let pool = SqlitePoolOptions::new()
             .max_connections(1)
             .connect_with(opts)
@@ -65,16 +80,16 @@ impl Store for SqliteStore {
         let mut tx = self.pool.begin().await?;
 
         // Progress table tracking the last processed block per event table.
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS _artemis_progress \
-             (table_name TEXT PRIMARY KEY, last_block INTEGER NOT NULL)",
-        )
+        sqlx::query(&format!(
+            "CREATE TABLE IF NOT EXISTS {PROGRESS_TABLE} \
+             (table_name TEXT PRIMARY KEY, last_block INTEGER NOT NULL)"
+        ))
         .execute(&mut *tx)
         .await?;
 
         // Create the table on demand: an implicit block_number column plus one
         // column per event field.
-        let mut defs = vec!["block_number INTEGER NOT NULL".to_string()];
+        let mut defs = vec![format!("{BLOCK_NUMBER_COLUMN} INTEGER NOT NULL")];
         for c in &schema.columns {
             defs.push(format!("{} {}", quote_ident(&c.name), c.ty.sql()));
         }
@@ -86,7 +101,7 @@ impl Store for SqliteStore {
         sqlx::query(&create).execute(&mut *tx).await?;
 
         // Insert every row in the block.
-        let mut col_names = vec!["block_number".to_string()];
+        let mut col_names = vec![BLOCK_NUMBER_COLUMN.to_string()];
         col_names.extend(schema.columns.iter().map(|c| quote_ident(&c.name)));
         let placeholders = vec!["?"; col_names.len()].join(", ");
         let insert = format!(
@@ -118,10 +133,10 @@ impl Store for SqliteStore {
         }
 
         // Advance the last processed block in the same transaction.
-        sqlx::query(
-            "INSERT INTO _artemis_progress (table_name, last_block) VALUES (?, ?) \
-             ON CONFLICT(table_name) DO UPDATE SET last_block = MAX(last_block, excluded.last_block)",
-        )
+        sqlx::query(&format!(
+            "INSERT INTO {PROGRESS_TABLE} (table_name, last_block) VALUES (?, ?) \
+             ON CONFLICT(table_name) DO UPDATE SET last_block = MAX(last_block, excluded.last_block)"
+        ))
         .bind(&schema.table)
         .bind(block as i64)
         .execute(&mut *tx)
@@ -132,7 +147,8 @@ impl Store for SqliteStore {
     }
 
     async fn last_block(&self, table: &str) -> Result<Option<u64>> {
-        let row = match sqlx::query("SELECT last_block FROM _artemis_progress WHERE table_name = ?")
+        let query = format!("SELECT last_block FROM {PROGRESS_TABLE} WHERE table_name = ?");
+        let row = match sqlx::query(&query)
             .bind(table)
             .fetch_optional(&self.pool)
             .await
@@ -153,7 +169,8 @@ impl Store for SqliteStore {
             .collect::<Vec<_>>()
             .join(", ");
         let sql = format!(
-            "SELECT {} FROM {} WHERE block_number <= ? ORDER BY block_number ASC, rowid ASC",
+            "SELECT {} FROM {} WHERE {BLOCK_NUMBER_COLUMN} <= ? \
+             ORDER BY {BLOCK_NUMBER_COLUMN} ASC, rowid ASC",
             select_cols,
             quote_ident(&schema.table)
         );

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -9,7 +9,7 @@ use alloy::{
 };
 use artemis_light::{
     collectors::{BlockCollector, EventCollector, LogCollector, MempoolCollector},
-    executors::{MempoolExecutor, SubmitTxToMempool},
+    executors::{GasBidInfo, MempoolExecutor, SubmitTxToMempool},
     types::{ActionStream, Collector, Executor},
 };
 
@@ -127,6 +127,98 @@ async fn test_mempool_executor_sends_tx_simple() {
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
     let tx = provider.get_transaction_count(account).await.unwrap();
     assert_eq!(tx, 1);
+}
+
+/// A bid percentage above 100 would spend more than the opportunity's total
+/// profit on gas — the transaction itself becomes the loss. The executor must
+/// refuse the action rather than overbid.
+#[tokio::test]
+async fn test_mempool_executor_rejects_bid_percentage_above_100() {
+    let (provider, _anvil) = spawn_anvil().await.unwrap();
+    let provider = Arc::new(provider);
+    let mut mempool_executor = MempoolExecutor::new(provider.clone());
+
+    let account = provider.get_accounts().await.unwrap()[0];
+    let tx = TransactionRequest::default()
+        .with_to(account)
+        .with_from(account)
+        .with_value(U256::from(42));
+
+    let action = SubmitTxToMempool {
+        tx,
+        gas_bid_info: Some(GasBidInfo {
+            total_profit: 1_000_000_000_000,
+            bid_percentage: 101,
+        }),
+    };
+    let err = mempool_executor.execute(action).await.unwrap_err();
+    assert!(
+        err.to_string().contains("bid_percentage"),
+        "error should name the invalid field, got: {err}"
+    );
+
+    // Nothing was sent.
+    assert_eq!(provider.get_transaction_count(account).await.unwrap(), 0);
+}
+
+/// With a gas bid, the executor prices the tx at
+/// `total_profit / gas_usage * bid_percentage / 100` and sets the gas limit
+/// from its own estimate (so the provider's filler doesn't re-estimate).
+#[tokio::test]
+async fn test_mempool_executor_prices_tx_from_gas_bid() {
+    use alloy::consensus::Transaction as _;
+
+    let (provider, _anvil) = spawn_anvil().await.unwrap();
+    let provider = Arc::new(provider);
+    let mut mempool_executor = MempoolExecutor::new(provider.clone());
+
+    let account = provider.get_accounts().await.unwrap()[0];
+    let tx = TransactionRequest::default()
+        .with_to(account)
+        .with_from(account)
+        .with_value(U256::from(42));
+
+    // A plain transfer estimates at 21_000 gas; a profit of 21_000 * 4 gwei
+    // makes the breakeven price 4 gwei, so a 50% bid prices at 2 gwei —
+    // comfortably above anvil's default 1 gwei base fee.
+    const GWEI: u128 = 1_000_000_000;
+    let action = SubmitTxToMempool {
+        tx,
+        gas_bid_info: Some(GasBidInfo {
+            total_profit: 21_000 * 4 * GWEI,
+            bid_percentage: 50,
+        }),
+    };
+    mempool_executor.execute(action).await.unwrap();
+
+    // Wait for the 1s-block chain to mine it, then find the (only) tx by
+    // scanning blocks from the tip down.
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    let tip = provider.get_block_number().await.unwrap();
+    let mut sent = None;
+    for n in (0..=tip).rev() {
+        let block = provider
+            .get_block(BlockId::Number(BlockNumberOrTag::Number(n)))
+            .await
+            .unwrap()
+            .unwrap();
+        if let Some(hash) = block.transactions.into_hashes().hashes().next() {
+            sent = provider.get_transaction_by_hash(hash).await.unwrap();
+            break;
+        }
+    }
+    let sent = sent.expect("the bid-priced transaction should have been mined");
+
+    assert_eq!(
+        sent.gas_price(),
+        Some(2 * GWEI),
+        "tx must be priced at breakeven * bid_percentage"
+    );
+    assert_eq!(
+        sent.gas_limit(),
+        21_000,
+        "the executor's estimate must be set as the gas limit"
+    );
 }
 
 /// Test that LogCollector receives logs emitted by a contract.

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -182,6 +182,43 @@ fn value_set_schema() -> TableSchema {
     }
 }
 
+/// A file-backed store must run in WAL journal mode. The default rollback
+/// journal takes an exclusive lock per write and answers concurrent access
+/// with an immediate SQLITE_BUSY — and a single failed write permanently
+/// halts persistence (by design, to keep the gap-free prefix). WAL plus a
+/// busy timeout makes a concurrent reader a non-event instead.
+#[tokio::test]
+async fn sqlite_store_uses_wal_for_file_databases() {
+    let path = std::env::temp_dir().join(format!("artemis_wal_test_{}.db", std::process::id()));
+    let _ = std::fs::remove_file(&path);
+    let url = format!("sqlite:{}", path.display());
+
+    // Connect and write through the store so the mode demonstrably holds on a
+    // live database, not just at open time.
+    let store = SqliteStore::connect(&url).await.unwrap();
+    store
+        .write_block(
+            &value_set_schema(),
+            1,
+            vec![Row(vec![SqlValue::Text("a".into())])],
+        )
+        .await
+        .unwrap();
+    drop(store);
+
+    // WAL is a persistent property of the database file; verify it with an
+    // independent plain connection.
+    let pool = sqlx::sqlite::SqlitePool::connect(&url).await.unwrap();
+    let (mode,): (String,) = sqlx::query_as("PRAGMA journal_mode")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    pool.close().await;
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(mode.to_lowercase(), "wal");
+}
+
 /// Slice 1: a written block can be read back via `replay`.
 #[tokio::test]
 async fn write_block_then_replay_reads_rows_back() {
@@ -339,6 +376,67 @@ fn derive_record_with_override_aligns_values_by_column_name() {
         panic!("payload column should be text");
     };
     assert_eq!(from_payload::<Transfer>(payload).unwrap(), event);
+}
+
+/// A store that accepts nothing and returns nothing — for tests that must
+/// fail before the store is ever touched.
+struct NullStore;
+
+#[async_trait]
+impl Store for NullStore {
+    async fn write_block(&self, _schema: &TableSchema, _block: u64, _rows: Vec<Row>) -> Result<()> {
+        unreachable!("the store must not be reached")
+    }
+    async fn last_block(&self, _table: &str) -> Result<Option<u64>> {
+        unreachable!("the store must not be reached")
+    }
+    async fn replay(&self, _schema: &TableSchema, _to: u64) -> Result<Vec<Row>> {
+        unreachable!("the store must not be reached")
+    }
+}
+
+/// A schema override naming a column the persistence layer adds implicitly
+/// (`block_number`, `_payload`) would produce a `CREATE TABLE` with duplicate
+/// columns — a SQL error that silently halts persistence on the first write.
+/// Misconfiguration must fail at construction instead.
+#[test]
+#[should_panic(expected = "reserved")]
+fn with_schema_rejects_reserved_column_names() {
+    let _ = FakeCollector::default()
+        .with_persistence(NullStore)
+        .with_schema(TableSchema::new("t").col("block_number", SqlType::Integer));
+}
+
+/// A schema override redirecting rows into the store's internal bookkeeping
+/// table would corrupt the progress watermarks of every other table.
+#[test]
+#[should_panic(expected = "reserved")]
+fn with_schema_rejects_the_progress_table() {
+    let _ = FakeCollector::default()
+        .with_persistence(NullStore)
+        .with_schema(TableSchema::new("_artemis_progress").col("value", SqlType::Text));
+}
+
+sol! {
+    // An event whose field collides with the implicit per-row block column.
+    #[derive(serde::Serialize, serde::Deserialize, Debug)]
+    event Sneaky(uint256 block_number);
+}
+
+/// An event field named after an implicit column cannot be stored — the
+/// derived `CREATE TABLE` would have duplicate columns and persistence would
+/// halt on the first write with an opaque SQL error. Deriving must fail with
+/// a clear message instead (which halts persistence loudly at the source).
+#[test]
+fn derive_rejects_event_fields_shadowing_implicit_columns() {
+    let event = Sneaky {
+        block_number: U256::from(1),
+    };
+    let err = derive_record(&event).unwrap_err().to_string();
+    assert!(
+        err.contains("reserved"),
+        "error should name the reserved column, got: {err}"
+    );
 }
 
 /// `payload_schema` describes the read-back shape — table name plus the single


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes persistence invariants (halt on reorg/derive failure) and transaction submission behavior; incorrect handling could stop archiving or reject valid txs, but the changes are defensive with broad test coverage.
> 
> **Overview**
> Hardens **event indexing**, **mempool execution**, and **SQLite persistence** so reorgs, bad bids, and schema/SQL edge cases cannot silently corrupt strategy state or archives.
> 
> **Event collection** now drops logs with `removed: true` (reorg retractions) and logs missing a block number via shared `indexed_event`, for live subscribe, indexed subscribe, and historical `query_range`.
> 
> **Mempool executor** rejects `bid_percentage` above 100 before RPC, documents the cap on `GasBidInfo`, and sets **gas limit** from the same estimate used to price the bid so fillers do not re-estimate.
> 
> **Persistence** stops writing on **non-monotone block order** or **row derive failure** (instead of logging and continuing), validates **reserved** table/column names at `with_schema` and derive time, and stores **u64 values above `i64::MAX`** as decimal text so queryable columns stay correct. **File-backed** `SqliteStore` uses WAL, `synchronous = NORMAL`, and a 5s busy timeout.
> 
> **Cargo**: library `tokio` features are trimmed; **`alloy` `node-bindings`** moves to dev-dependencies for tests/examples only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b068acad37558142f3828254001d5bed5f2467eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->