### PR TITLE
polish: fix the review's remaining UX, docs, and small-efficiency fin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ The **Engine** fans-out every event to every strategy via a `tokio::sync::broadc
 
 | Layer | Type | Description |
 |---|---|---|
-| **Collector** | `BlockCollector` | Subscribes to new blocks via WebSocket |
+| **Collector** | `BlockCollector` | Subscribes to new blocks via WebSocket (falls back to polling) |
 | | `MempoolCollector` | Subscribes to pending transactions in the mempool |
 | | `LogCollector` | Subscribes to on-chain event logs matching a filter |
 | | `EventCollector` | Subscribes to an arbitrary `alloy` subscription |
 | **Strategy** | `Strategy<E, A>` | User-defined: receives events, produces action streams |
 | **Executor** | `MempoolExecutor` | Submits transactions to the public mempool |
+| **Observer** | `Observer<E, A>` | Passive consumer of every event and action crossing the channels |
 | **Persistence** | `Persisted<C, S>` | Wraps a block-aware collector to record events to a SQL `Store` and replay them on restart |
 
 ## Combinators
@@ -46,12 +47,28 @@ let collector = mempool_collector.filter_map(|tx| {
 let collector = block_collector.merge(mempool_collector);
 ```
 
-**Executor combinators:**
+## Observers
 
-| Combinator | Description |
-|---|---|
-| `ExecutorFilterMap` | Filter-maps actions before forwarding to an inner executor |
-| `.instrument(metrics)` | Wraps an executor (or strategy) with a `Metrics` callback |
+An **Observer** is one more subscriber on the engine's event and action
+channels: it sees everything strategies and executors see while producing and
+perturbing nothing. Observation is best-effort (a lagging observer skips
+messages like any consumer) and infallible by design — there is no error
+channel through which observing could fail the pipeline. Use it for metrics,
+logging, or shadow analysis:
+
+```rust
+use artemis_light::types::Observer;
+
+struct Telemetry;
+
+#[async_trait::async_trait]
+impl Observer<MyEvent, MyAction> for Telemetry {
+    async fn observe_event(&mut self, event: MyEvent) { /* count it */ }
+    async fn observe_action(&mut self, action: MyAction) { /* count it */ }
+}
+
+engine.add_observer(Box::new(Telemetry));
+```
 
 ## Persistence
 

--- a/examples/basic_example.rs
+++ b/examples/basic_example.rs
@@ -59,35 +59,54 @@ impl Strategy<u64, u64> for DoubleStrategy {
     }
 }
 
-/// An executor that prints each action it receives.
-struct PrintExecutor;
+/// An executor that prints each action it receives and signals `done` once it
+/// has handled the expected number of actions.
+struct PrintExecutor {
+    remaining: u64,
+    done: Option<tokio::sync::oneshot::Sender<()>>,
+}
 
 #[async_trait]
 impl Executor<u64> for PrintExecutor {
     async fn execute(&mut self, action: u64) -> Result<()> {
         println!("[executor] action = {action}");
+        self.remaining = self.remaining.saturating_sub(1);
+        if self.remaining == 0
+            && let Some(done) = self.done.take()
+        {
+            let _ = done.send(());
+        }
         Ok(())
     }
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    const TICKS: u64 = 5;
+
     // Build a collector and use `.map()` to add 100 to every tick.
     let collector =
-        TickCollector::new(std::time::Duration::from_millis(500), 5).map(|tick| tick + 100);
+        TickCollector::new(std::time::Duration::from_millis(500), TICKS).map(|tick| tick + 100);
+
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel();
 
     let mut engine = Engine::<u64, u64>::default();
     engine.add_collector(Box::new(collector));
     engine.add_strategy(Box::new(DoubleStrategy));
-    engine.add_executor(Box::new(PrintExecutor));
+    engine.add_executor(Box::new(PrintExecutor {
+        remaining: TICKS,
+        done: Some(done_tx),
+    }));
 
-    println!("Starting engine — will process 5 ticks then exit...\n");
-    let mut handle = engine.run().await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    println!("Starting engine — will process {TICKS} ticks then exit...\n");
+    let mut handle = engine.run().await?;
 
-    // Wait for all tasks to finish (the finite collector will complete).
-    tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+    // Run until the executor reports the last action handled, then shut down
+    // cooperatively: cancel the token and wait for every task to exit. A real
+    // binary would select between this and Ctrl-C / `handle.fatal` (see the
+    // README's minimal example).
+    let _ = done_rx.await;
     handle.token.cancel();
-
     while handle.tasks.join_next().await.is_some() {}
 
     println!("\nDone!");

--- a/src/collectors/block_collector.rs
+++ b/src/collectors/block_collector.rs
@@ -35,31 +35,46 @@ where
     M: Provider,
 {
     async fn subscribe(&self) -> Result<CollectorStream<'_, NewBlock>> {
-        if let Ok(subscription) = self.provider.subscribe_blocks().await {
-            let stream = subscription.into_stream().map(|header| NewBlock {
-                hash: header.hash,
-                number: header.number,
-            });
-            Ok(Box::pin(stream) as CollectorStream<'_, NewBlock>)
-        } else {
-            warn!("Error subscribing to blocks; polling instead");
-            let stream = self
-                .provider
-                .watch_full_blocks()
-                .await?
-                .into_stream()
-                .filter_map(|block| match block {
-                    Ok(block) => Some(block.header),
-                    Err(e) => {
-                        warn!("Error polling full block; skipping: {e}");
-                        None
-                    }
-                })
-                .map(|header| NewBlock {
+        match self.provider.subscribe_blocks().await {
+            Ok(subscription) => {
+                let stream = subscription.into_stream().map(|header| NewBlock {
                     hash: header.hash,
                     number: header.number,
                 });
-            Ok(Box::pin(stream) as CollectorStream<'_, NewBlock>)
+                Ok(Box::pin(stream) as CollectorStream<'_, NewBlock>)
+            }
+            Err(e) => {
+                // Most commonly a transport without pubsub (plain HTTP).
+                // Surface the reason for the downgrade rather than hiding it.
+                warn!("Error subscribing to blocks ({e}); polling instead");
+
+                // Poll block *hashes* and fetch each header on demand. A
+                // `NewBlock` needs only the header, so polling full blocks
+                // would download every transaction body just to throw it away.
+                let mut hashes = self.provider.watch_blocks().await?.into_stream();
+                let provider = self.provider.clone();
+                let stream = async_stream::stream! {
+                    while let Some(batch) = hashes.next().await {
+                        for hash in batch {
+                            match provider.get_block_by_hash(hash).await {
+                                Ok(Some(block)) => {
+                                    yield NewBlock {
+                                        hash: block.header.hash,
+                                        number: block.header.number,
+                                    };
+                                }
+                                Ok(None) => {
+                                    warn!("Polled block {hash} not found; skipping")
+                                }
+                                Err(e) => {
+                                    warn!("Error fetching polled block {hash}; skipping: {e}")
+                                }
+                            }
+                        }
+                    }
+                };
+                Ok(Box::pin(stream) as CollectorStream<'_, NewBlock>)
+            }
         }
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -143,7 +143,11 @@ where
     ///
     /// Returns an [`EngineHandle`] carrying the shutdown token, the running
     /// tasks, and a one-shot that fires if a collector becomes unrecoverable.
-    pub async fn run(self) -> Result<EngineHandle, Box<dyn std::error::Error>> {
+    ///
+    /// Errors are [`anyhow::Error`], matching every other fallible API in the
+    /// crate, so `engine.run().await?` composes in an `anyhow` (or plain
+    /// `Box<dyn Error>`) `main` without a conversion shim.
+    pub async fn run(self) -> anyhow::Result<EngineHandle> {
         let (event_sender, _): (Sender<E>, _) = broadcast::channel(self.event_channel_capacity);
         let (action_sender, _): (Sender<A>, _) = broadcast::channel(self.action_channel_capacity);
 
@@ -259,7 +263,7 @@ where
                             fatal,
                         });
                     }
-                    return Err("engine cancelled during strategy sync".into());
+                    return Err(anyhow::anyhow!("engine cancelled during strategy sync"));
                 }
                 result = strategy.sync_state() => {
                     result?;

--- a/src/persistence/record.rs
+++ b/src/persistence/record.rs
@@ -24,17 +24,22 @@ pub fn table_name<E: SolEvent>() -> String {
     to_snake_case(name)
 }
 
+/// Serialise an event to its JSON [`Value`] — the single serialisation pass
+/// both the field map and the payload column are derived from.
+fn event_json<E: Serialize>(event: &E) -> Result<Value> {
+    serde_json::to_value(event).context("event is not serialisable to JSON")
+}
+
 /// Map an event's top-level fields to `name -> (best-guess type, value)`,
 /// sorted by field name (deterministic across runs).
-fn field_map<E: Serialize>(event: &E) -> Result<BTreeMap<String, (SqlType, SqlValue)>> {
-    let value = serde_json::to_value(event).context("event is not serialisable to JSON")?;
+fn field_map(value: &Value) -> Result<BTreeMap<String, (SqlType, SqlValue)>> {
     let object = match value {
         Value::Object(map) => map,
         other => anyhow::bail!("event must serialise to a JSON object, got {other}"),
     };
     Ok(object
-        .into_iter()
-        .map(|(key, field)| (key, (infer_type(&field), json_to_sql(&field))))
+        .iter()
+        .map(|(key, field)| (key.clone(), (infer_type(field), json_to_sql(field))))
         .collect())
 }
 
@@ -44,7 +49,7 @@ pub fn derive<E>(event: &E) -> Result<(TableSchema, Row)>
 where
     E: Serialize + SolEvent,
 {
-    let fields = field_map(event)?;
+    let fields = field_map(&event_json(event)?)?;
     let mut columns = Vec::with_capacity(fields.len());
     let mut values = Vec::with_capacity(fields.len());
     for (name, (ty, value)) in fields {
@@ -85,7 +90,10 @@ pub fn derive_record_with<E>(
 where
     E: Serialize + SolEvent,
 {
-    let fields = field_map(event)?;
+    // One serialisation pass feeds both the field map and the payload column;
+    // this runs once per event on the persistence hot path.
+    let json = event_json(event)?;
+    let fields = field_map(&json)?;
 
     let (table, columns, mut values) = match override_ {
         Some(schema) => {
@@ -129,7 +137,7 @@ where
     };
 
     let mut schema = TableSchema { table, columns };
-    let payload = serde_json::to_string(event).context("event is not serialisable to JSON")?;
+    let payload = json.to_string();
     schema
         .columns
         .push(Column::new(PAYLOAD_COLUMN, SqlType::Text));

--- a/src/persistence/schema.rs
+++ b/src/persistence/schema.rs
@@ -119,30 +119,10 @@ pub struct Row(pub Vec<SqlValue>);
 mod tests {
     use super::*;
 
-    #[test]
-    fn sql_type_maps_to_create_table_keyword() {
-        assert_eq!(SqlType::Integer.sql(), "INTEGER");
-        assert_eq!(SqlType::Real.sql(), "REAL");
-        assert_eq!(SqlType::Text.sql(), "TEXT");
-        assert_eq!(SqlType::Blob.sql(), "BLOB");
-        assert_eq!(SqlType::Numeric.sql(), "NUMERIC");
-    }
-
-    #[test]
-    fn column_new_accepts_str_and_string() {
-        assert_eq!(
-            Column::new("amount", SqlType::Numeric),
-            Column {
-                name: "amount".to_string(),
-                ty: SqlType::Numeric,
-            }
-        );
-        // `impl Into<String>` so an owned String works too.
-        assert_eq!(
-            Column::new(String::from("amount"), SqlType::Numeric).name,
-            "amount"
-        );
-    }
+    // Construction helpers (`SqlType::sql`, `Column::new`, `TableSchema::new`)
+    // are restatements of their own definitions; testing them asserts nothing
+    // a regression could violate. Only the builder's ordering contract — which
+    // value alignment in `derive_record_with` depends on — is worth pinning.
 
     #[test]
     fn table_schema_builder_appends_columns_in_order() {
@@ -158,10 +138,5 @@ mod tests {
                 Column::new("amount", SqlType::Numeric),
             ]
         );
-    }
-
-    #[test]
-    fn new_table_schema_starts_empty() {
-        assert!(TableSchema::new("transfer").columns.is_empty());
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -72,6 +72,37 @@ async fn test_block_collector_sends_blocks() {
     assert_eq!(block_a.hash, block_b.header.hash);
 }
 
+/// Over plain HTTP there is no pubsub, so `subscribe_blocks` fails and the
+/// collector must fall back to polling — and still deliver new blocks.
+#[tokio::test]
+async fn test_block_collector_polls_when_subscriptions_are_unavailable() {
+    let anvil = Anvil::new()
+        .block_time(1)
+        .chain_id(1337)
+        .try_spawn()
+        .unwrap();
+    let provider = ProviderBuilder::new().connect_http(anvil.endpoint().parse().unwrap());
+    let provider = Arc::new(provider);
+    let block_collector = BlockCollector::new(provider.clone());
+
+    let block_stream = block_collector.subscribe().await.unwrap();
+    let block = tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        block_stream.into_future(),
+    )
+    .await
+    .expect("polling fallback should deliver a block within 15s")
+    .0
+    .unwrap();
+
+    let chain_block = provider
+        .get_block(BlockId::Number(BlockNumberOrTag::Number(block.number)))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(block.hash, chain_block.header.hash);
+}
+
 /// Test that mempool collector correctly emits blocks.
 #[tokio::test]
 async fn test_mempool_collector_sends_txs() {
@@ -887,6 +918,39 @@ mod engine_tests {
             vec![1, 2, 3],
             "a strategy registered after another's sync must not miss events \
              broadcast during that sync"
+        );
+    }
+
+    /// A strategy whose `sync_state` errors must surface that error from
+    /// `Engine::run` — it is the only fallible user hook in the run loop, and
+    /// a regression that swallowed it would start the pipeline on unsynced
+    /// state silently.
+    #[tokio::test]
+    async fn test_engine_run_surfaces_strategy_sync_error() {
+        struct FailingSyncStrategy;
+
+        #[async_trait]
+        impl Strategy<u32, u32> for FailingSyncStrategy {
+            async fn sync_state(&mut self) -> Result<()> {
+                Err(anyhow::anyhow!("sync exploded"))
+            }
+            async fn process_event(&mut self, event: u32) -> Result<ActionStream<'_, u32>> {
+                Ok(Box::pin(futures::stream::iter(vec![event])))
+            }
+        }
+
+        let mut engine = Engine::<u32, u32>::default();
+        engine.add_collector(Box::new(FixedCollector::new(vec![1])));
+        engine.add_strategy(Box::new(FailingSyncStrategy));
+
+        let err = engine
+            .run()
+            .await
+            .err()
+            .expect("a failing sync_state must fail run");
+        assert!(
+            err.to_string().contains("sync exploded"),
+            "the strategy's own error must surface, got: {err}"
         );
     }
 


### PR DESCRIPTION
…dings

Closes out the low-severity items from the repository review:

- Engine::run returns anyhow::Result instead of Box<dyn Error>. The old error type was neither Send nor Sync, so it didn't convert into anyhow::Error — every consumer had to copy the examples' map_err shim. anyhow matches every other fallible API in the crate, and still composes with a plain Box<dyn Error> main. Also adds the previously missing test that a strategy's sync_state error actually surfaces from run().

- basic_example shuts down deterministically: the executor signals a oneshot after the last action instead of the old sleep-4-seconds-and-hope, whose comment claimed it "waits for all tasks to finish". The example now also models a real run-until-condition shutdown and exits ~1.5s sooner.

- BlockCollector's polling fallback polls block hashes and fetches headers instead of watch_full_blocks, which downloaded every transaction body just to keep the header. The subscribe error that triggers the downgrade is now logged instead of silently discarded, and the fallback branch — previously untested — gets an HTTP-provider integration test.

- derive_record_with serialises each event once: the JSON Value feeds both the field map and the payload column, instead of two independent serde passes per event on the persistence hot path. (Payload key order is now sorted; replay parses either form.)

- schema.rs drops three tautological tests (a verbatim restatement of SqlType::sql's match, an Into<String> exercise, and a fresh-Vec-is-empty assert), keeping the builder-ordering pin that value alignment depends on.

- README: the combinators section documented ExecutorFilterMap and .instrument(metrics), neither of which exists since the Observer seam replaced Metrics (commit 81834a5); replaced with an Observers section and an Observer row in the components table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation, examples, and non-breaking behavior improvements; `Engine::run`'s error type is a small public API tweak that aligns with anyhow elsewhere.
> 
> **Overview**
> Polishes **UX, docs, and small hot-path efficiency** from review follow-ups—no new pipeline features.
> 
> **`Engine::run`** now returns **`anyhow::Result<EngineHandle>`** so callers can use `?` like the rest of the crate; cancellation during strategy sync uses **`anyhow`** errors. A new engine test asserts **`sync_state` failures propagate** from `run`.
> 
> **`basic_example`** shuts down when the executor finishes the last action (oneshot) instead of a fixed sleep, and uses plain **`engine.run().await?`**.
> 
> **`BlockCollector`** HTTP fallback **polls block hashes and fetches headers** (not full blocks), **logs** the subscribe failure that triggers polling, and gains an **HTTP integration test** for that path.
> 
> **Persistence** **`derive_record_with`** does **one `serde_json` pass** for both field columns and `_payload` (payload key order may be sorted; replay still accepts either).
> 
> **README** documents **Observers** and drops stale **executor combinator / Metrics** text; **`BlockCollector`** is noted as WS with polling fallback. **`schema.rs`** drops redundant constructor tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e5eba131bbb0e92aafcd3f2e1a3363bab2dd27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->