### PR TITLE
refactor: introduce Record as the owner of the event <-> SQL row mapping

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,6 +45,10 @@ _Avoid_: concat, append
 A Collector wrapper that records every event it sees into a Store and, on subscribe, delivers three **Segments** in fixed order: **Replay**, then **Backfill**, then the **Live Tail**.
 _Avoid_: indexer, archiver, recorder
 
+**Record**:
+The mapping between one event type and its SQL rows. It owns the table name, the column schema — declared via an override (validated at construction, where a bad override panics) or frozen from the first encoded event — the encode-to-row and decode-from-payload directions, and the reserved-name invariant. The Store sees only the schemas and rows a Record produces.
+_Avoid_: codec, row mapper, serializer
+
 **Segment**:
 One of the three ordered parts of a Persisted Collector's subscription. The order — Replay → Backfill → Live Tail — is fixed; the Segments are disjoint, split at the chain tip observed during subscribe.
 
@@ -66,6 +70,7 @@ _Avoid_: live stream, subscription
 - A **Merge** or **Chain** composite is one **Collector** to the **Engine**: its sources share one **Collector Driver** and one **Reconnect Policy** (one lifecycle). Register sources as separate Collectors instead when each should reconnect — and go **Fatal** — independently.
 - A **Reconnect Policy** counts consecutive stream failures and resets that count only when its **Collector Driver** reports a delivered event.
 - A **Persisted Collector** pairs one **Collector** (block-aware) with one Store; its subscription is the chain Replay → Backfill → Live Tail.
+- A **Persisted Collector** constructs one **Record** per subscription; every row written to or replayed from the Store passes through it.
 - A **Fatal** verdict cancels the observe-only fatal token, then the root token shared by all **Collector**, **Strategy**, and **Executor** tasks; the binary observes the fatal token and decides to exit.
 - An **Engine** spawns one task per **Observer**, subscribed to both channels; an Observer has no feedback path into the pipeline.
 

--- a/src/collector_ext/filter_map.rs
+++ b/src/collector_ext/filter_map.rs
@@ -17,6 +17,27 @@ impl<E, F> FilterMap<E, F> {
     }
 }
 
+/// Subscribe `collector` and adapt its stream through `f`, discarding `None`
+/// results and unwrapping `Some` — the one stream-adaptation site shared by
+/// [`FilterMap`] and [`Map`](super::Map) (a map is a filter-map that never
+/// discards).
+pub(super) async fn subscribe_filter_mapped<'a, E1, E2, F>(
+    collector: &'a dyn Collector<E1>,
+    f: F,
+) -> Result<CollectorStream<'a, E2>>
+where
+    E1: Send + Sync + 'static,
+    E2: Send + Sync + 'static,
+    F: Fn(E1) -> Option<E2> + Send + Sync + Clone + 'static,
+{
+    let stream = collector.subscribe().await?;
+    let stream = stream.filter_map(move |event| {
+        let f = f.clone();
+        async move { f(event) }
+    });
+    Ok(Box::pin(stream))
+}
+
 #[async_trait]
 impl<E1, E2, F> Collector<E2> for FilterMap<E1, F>
 where
@@ -25,12 +46,6 @@ where
     F: Fn(E1) -> Option<E2> + Send + Sync + Clone + 'static,
 {
     async fn subscribe(&self) -> Result<CollectorStream<'_, E2>> {
-        let stream = self.collector.subscribe().await?;
-        let f = self.f.clone();
-        let stream = stream.filter_map(move |event| {
-            let f = f.clone();
-            async move { f(event) }
-        });
-        Ok(Box::pin(stream))
+        subscribe_filter_mapped(&*self.collector, self.f.clone()).await
     }
 }

--- a/src/collector_ext/map.rs
+++ b/src/collector_ext/map.rs
@@ -1,10 +1,12 @@
 use crate::types::{Collector, CollectorStream};
 use anyhow::Result;
 use async_trait::async_trait;
-use futures::StreamExt;
+
+use super::filter_map::subscribe_filter_mapped;
 
 /// `Map` is a wrapper around a [Collector] that maps outgoing
-/// events to a different type.
+/// events to a different type: a [`FilterMap`](super::FilterMap)
+/// that never discards.
 pub struct Map<E, F> {
     collector: Box<dyn Collector<E>>,
     f: F,
@@ -25,9 +27,7 @@ where
     F: Fn(E1) -> E2 + Send + Sync + Clone + 'static,
 {
     async fn subscribe(&self) -> Result<CollectorStream<'_, E2>> {
-        let stream = self.collector.subscribe().await?;
         let f = self.f.clone();
-        let stream = stream.map(f);
-        Ok(Box::pin(stream))
+        subscribe_filter_mapped(&*self.collector, move |event| Some(f(event))).await
     }
 }

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -5,7 +5,9 @@
 //! block. The [`Persisted`](crate::persistence::Persisted) wrapper turns any
 //! block-aware collector into one that records every event it sees and, on
 //! subscribe, replays the stored history before catching up to and following
-//! the chain tip.
+//! the chain tip. Every row written to or replayed from the Store passes
+//! through a [`Record`](crate::persistence::Record), the mapping between one
+//! event type and its SQL rows.
 
 mod persisted;
 mod record;
@@ -14,7 +16,7 @@ mod sqlite;
 mod store;
 
 pub use persisted::*;
-pub use record::*;
+pub use record::Record;
 pub use schema::*;
 pub use sqlite::*;
 pub use store::*;

--- a/src/persistence/persisted.rs
+++ b/src/persistence/persisted.rs
@@ -1,6 +1,7 @@
 //! [`Persisted`]: a [`Collector`] wrapper that records every event it sees and,
 //! on subscribe, replays stored history before following the chain tip.
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use alloy::sol_types::SolEvent;
@@ -11,8 +12,8 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio_util::sync::CancellationToken;
 
-use super::record::{derive_record_with, from_payload, table_name};
-use super::schema::{PAYLOAD_COLUMN, Row, SqlType, SqlValue, TableSchema};
+use super::record::Record;
+use super::schema::{Row, SqlValue, TableSchema};
 use super::store::Store;
 use crate::types::{Collector, CollectorStream};
 
@@ -167,13 +168,13 @@ where
         let live_source = self.collector.subscribe_indexed().await?;
         let tip = self.collector.tip().await?;
 
-        // The table name follows the declared schema, if any.
-        let table = self
-            .schema
-            .as_ref()
-            .map(|schema| schema.table.clone())
-            .unwrap_or_else(table_name::<E>);
-        let last = self.store.last_block(&table).await?;
+        // The Record fixes the table name and owns the event <-> row mapping
+        // for the whole subscription; the override was already validated in
+        // `with_schema`, so this only fails on a library bug. Shared (Arc)
+        // between the backfill and live writers, so a schema frozen during
+        // backfill is reused by the live tail.
+        let record = Arc::new(Record::<E>::new(self.schema.clone())?);
+        let last = self.store.last_block(record.table()).await?;
 
         // 1. Replay stored history, reconstructed from the database — but only
         //    on the first subscribe. On a reconnect the engine subscribes again;
@@ -182,7 +183,7 @@ where
         //    the backfill segment cover only the gap since the last stored block.
         let first_subscribe = !self.replayed.load(Ordering::SeqCst);
         let replay: CollectorStream<'_, E> = if first_subscribe {
-            let inner = replay_stored::<E, S>(&self.store, table, last).await?;
+            let inner = replay_stored(&self.store, &record, last).await?;
             // Flip the replay-once flag when the archive is first *consumed*,
             // not merely when `subscribe` succeeds. The engine retries
             // `subscribe` on error, but it also discards the returned stream
@@ -231,7 +232,7 @@ where
             )
             .await?
         };
-        let backfill = persist_and_emit(backfill_source, &self.store, self.schema.as_ref(), true);
+        let backfill = persist_and_emit(backfill_source, &self.store, record.clone(), true);
 
         // 3. Live tail, strictly above the backfill cut so the two segments are
         //    disjoint. A live subscription streams from "now", whose lower edge
@@ -263,7 +264,7 @@ where
                 })
                 .take_until(poison.cancelled_owned()),
         ) as CollectorStream<'_, (u64, E)>;
-        let live = persist_and_emit(live_source, &self.store, self.schema.as_ref(), false);
+        let live = persist_and_emit(live_source, &self.store, record, false);
 
         Ok(Segments {
             replay,
@@ -278,19 +279,18 @@ where
 /// row's payload column. Returns an empty stream when nothing is stored.
 async fn replay_stored<'a, E, S>(
     store: &'a S,
-    table: String,
+    record: &Record<E>,
     last: Option<u64>,
 ) -> Result<CollectorStream<'a, E>>
 where
-    E: DeserializeOwned + SolEvent + Send + 'a,
+    E: DeserializeOwned + Send + 'a,
     S: Store + 'a,
 {
     let Some(to) = last else {
         return Ok(Box::pin(futures::stream::empty()));
     };
 
-    let payload_schema = TableSchema::new(table).col(PAYLOAD_COLUMN, SqlType::Text);
-    let rows = store.replay(&payload_schema, to).await?;
+    let rows = store.replay(&record.payload_schema(), to).await?;
     // A stored row that cannot be reconstructed is a hard error, not a row to
     // skip: replay feeds strategies the historical view they reason over, and
     // `_artemis_progress` already counts these blocks as processed. Silently
@@ -299,7 +299,7 @@ where
     let mut events = Vec::with_capacity(rows.len());
     for Row(cols) in rows {
         match cols.into_iter().next() {
-            Some(SqlValue::Text(payload)) => events.push(from_payload::<E>(&payload)?),
+            Some(SqlValue::Text(payload)) => events.push(record.decode(&payload)?),
             other => anyhow::bail!("unexpected payload column on replay: {other:?}"),
         }
     }
@@ -376,15 +376,15 @@ where
 fn persist_and_emit<'a, E, S>(
     mut source: CollectorStream<'a, (u64, E)>,
     store: &'a S,
-    override_: Option<&'a TableSchema>,
+    record: Arc<Record<E>>,
     flush_final: bool,
 ) -> CollectorStream<'a, E>
 where
-    E: Serialize + SolEvent + Send + Sync + 'static,
+    E: Serialize + Send + Sync + 'static,
     S: Store + 'a,
 {
     let stream = async_stream::stream! {
-        let mut writer = BlockWriter::new(store, override_);
+        let mut writer = BlockWriter::new(store, record);
 
         while let Some((block, event)) = source.next().await {
             writer.record(block, &event).await;
@@ -411,36 +411,34 @@ where
 /// restart re-fetches everything after the last good block.
 ///
 /// [`finish`]: BlockWriter::finish
-struct BlockWriter<'a, S> {
+struct BlockWriter<'a, S, E> {
     store: &'a S,
-    override_: Option<&'a TableSchema>,
+    record: Arc<Record<E>>,
     buffer: Vec<Row>,
     current: Option<u64>,
-    schema: Option<TableSchema>,
     healthy: bool,
 }
 
-impl<'a, S: Store> BlockWriter<'a, S> {
-    fn new(store: &'a S, override_: Option<&'a TableSchema>) -> Self {
+impl<'a, S: Store, E: Serialize> BlockWriter<'a, S, E> {
+    fn new(store: &'a S, record: Arc<Record<E>>) -> Self {
         Self {
             store,
-            override_,
+            record,
             buffer: Vec::new(),
             current: None,
-            schema: None,
             healthy: true,
         }
     }
 
     /// Buffer one event's row, first flushing the previous block if `block`
     /// has advanced past it. No-op once unhealthy.
-    async fn record<E: Serialize + SolEvent>(&mut self, block: u64, event: &E) {
+    async fn record(&mut self, block: u64, event: &E) {
         if !self.healthy {
             return;
         }
-        match derive_record_with(event, self.override_) {
-            Ok((row_schema, row)) => {
-                if let (Some(cur), Some(sch)) = (self.current, &self.schema) {
+        match self.record.encode(event) {
+            Ok(row) => {
+                if let Some(cur) = self.current {
                     // A backwards block means the open block's completeness
                     // can no longer be trusted: flushing it would advance the
                     // stored height past the late block's rows, leaving a
@@ -452,10 +450,13 @@ impl<'a, S: Store> BlockWriter<'a, S> {
                         ));
                         return;
                     }
-                    // The block advanced: the previous block is complete.
+                    // The block advanced: the previous block is complete. The
+                    // schema is always present here — `current` is only set
+                    // after a successful encode, which froze it.
                     if block > cur {
+                        let schema = self.record.schema().expect("frozen by first encode");
                         self.healthy =
-                            flush(self.store, sch, cur, std::mem::take(&mut self.buffer)).await;
+                            flush(self.store, &schema, cur, std::mem::take(&mut self.buffer)).await;
                         if !self.healthy {
                             // This event's block can never be written without
                             // leaving a gap, so don't buffer its row either.
@@ -464,15 +465,14 @@ impl<'a, S: Store> BlockWriter<'a, S> {
                     }
                 }
                 self.current = Some(block);
-                self.schema = Some(row_schema);
                 self.buffer.push(row);
             }
-            // An event that can't be derived into a row can never be written,
+            // An event that can't be encoded into a row can never be written,
             // so its block — and everything after it — must not be either:
             // progress advancing past it would hand the next restart exactly
             // the quietly truncated history `replay_stored` refuses to emit.
             // The event stream itself keeps flowing.
-            Err(e) => self.halt(format_args!("failed to derive row: {e}")),
+            Err(e) => self.halt(format_args!("failed to encode row: {e}")),
         }
     }
 
@@ -492,9 +492,10 @@ impl<'a, S: Store> BlockWriter<'a, S> {
     /// block completely (a finite backfill range, not a live tail).
     async fn finish(&mut self) {
         if self.healthy
-            && let (Some(cur), Some(sch)) = (self.current, &self.schema)
+            && let Some(cur) = self.current
         {
-            flush(self.store, sch, cur, std::mem::take(&mut self.buffer)).await;
+            let schema = self.record.schema().expect("frozen by first encode");
+            flush(self.store, &schema, cur, std::mem::take(&mut self.buffer)).await;
         }
     }
 
@@ -536,14 +537,38 @@ mod tests {
 
     alloy::sol! {
         // No serde derive: `Serialize` is implemented by hand below to produce
-        // a non-object JSON value, which `derive_record_with` rejects.
+        // a non-object JSON value — which `Record::encode` rejects — for the
+        // zero value only, so one writer can see good and bad events of the
+        // same type.
         event BadPing(uint256 value);
     }
 
     impl serde::Serialize for BadPing {
         fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-            serializer.serialize_str("not a JSON object")
+            if self.value.is_zero() {
+                serializer.serialize_str("not a JSON object")
+            } else {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("value", &self.value.to_string())?;
+                map.end()
+            }
         }
+    }
+
+    fn bad_ping(value: u64) -> BadPing {
+        BadPing {
+            value: alloy::primitives::U256::from(value),
+        }
+    }
+
+    /// A writer over a fresh inferred [`Record`] for `E`.
+    fn writer<S, E>(store: &S) -> BlockWriter<'_, S, E>
+    where
+        S: Store,
+        E: alloy::sol_types::SolEvent + Serialize,
+    {
+        BlockWriter::new(store, Arc::new(Record::new(None).unwrap()))
     }
 
     /// A store whose every write fails.
@@ -606,7 +631,7 @@ mod tests {
     #[tokio::test]
     async fn writer_stops_buffering_once_unhealthy() {
         let store = FailingStore;
-        let mut writer = BlockWriter::new(&store, None);
+        let mut writer = writer::<_, Ping>(&store);
 
         // Block 1 buffers normally.
         writer.record(1, &ping(1)).await;
@@ -639,7 +664,7 @@ mod tests {
     #[tokio::test]
     async fn writer_halts_on_non_monotone_blocks_without_writing() {
         let store = RecordingStore::default();
-        let mut writer = BlockWriter::new(&store, None);
+        let mut writer = writer::<_, Ping>(&store);
 
         writer.record(5, &ping(1)).await;
         writer.record(4, &ping(2)).await; // block went backwards
@@ -654,26 +679,19 @@ mod tests {
         assert_eq!(writer.buffered(), 0);
     }
 
-    /// An event that cannot be derived into a row must halt persistence, not
+    /// An event that cannot be encoded into a row must halt persistence, not
     /// be skipped: progress would otherwise advance past its block, and replay
     /// would hand strategies exactly the "quietly truncated history" the read
     /// side refuses to produce (see `replay_stored`). Strategies that ran live
     /// saw the event; strategies after a restart must not silently lose it.
     #[tokio::test]
-    async fn writer_halts_on_underivable_event_instead_of_leaving_a_hole() {
+    async fn writer_halts_on_unencodable_event_instead_of_leaving_a_hole() {
         let store = RecordingStore::default();
-        let mut writer = BlockWriter::new(&store, None);
+        let mut writer = writer::<_, BadPing>(&store);
 
-        writer.record(1, &ping(1)).await;
-        writer
-            .record(
-                2,
-                &BadPing {
-                    value: alloy::primitives::U256::ZERO,
-                },
-            )
-            .await;
-        writer.record(3, &ping(3)).await; // would previously flush past block 2
+        writer.record(1, &bad_ping(1)).await;
+        writer.record(2, &bad_ping(0)).await; // zero serialises unencodably
+        writer.record(3, &bad_ping(3)).await; // would previously flush past block 2
         writer.finish().await;
 
         assert_eq!(

--- a/src/persistence/record.rs
+++ b/src/persistence/record.rs
@@ -1,10 +1,19 @@
-//! Best-guess mapping between events and SQL rows.
+//! The [`Record`]: the mapping between one event type and its SQL rows.
 //!
-//! The table name comes from the event's Solidity signature; column names come
-//! from the event's `serde` field names and column types are inferred from the
-//! serialised JSON. This requires events to implement [`serde::Serialize`].
+//! A `Record` owns the table name, the column schema — declared via an
+//! override or frozen from the first encoded event — and both directions of
+//! the mapping: encode an event to a [`Row`], decode a stored payload back to
+//! the event. It also owns the reserved-name invariant; the
+//! [`Store`](super::Store) sees only the schemas and rows a `Record` produces.
+//!
+//! Without a declared schema the mapping is a best guess: the table name comes
+//! from the event's Solidity signature, column names from the event's `serde`
+//! field names, and column types are inferred from the serialised JSON. This
+//! requires events to implement [`serde::Serialize`].
 
 use std::collections::BTreeMap;
+use std::marker::PhantomData;
+use std::sync::OnceLock;
 
 use alloy::sol_types::SolEvent;
 use anyhow::{Context, Result};
@@ -16,9 +25,163 @@ use super::schema::{
     BLOCK_NUMBER_COLUMN, Column, PAYLOAD_COLUMN, Row, SqlType, SqlValue, TableSchema,
 };
 
+/// The mapping between the event type `E` and its SQL rows. See the
+/// [module docs](self).
+pub struct Record<E> {
+    table: String,
+    columns: ColumnsSource,
+    _event: PhantomData<fn() -> E>,
+}
+
+/// Where a [`Record`]'s event-field columns come from.
+enum ColumnsSource {
+    /// Declared via a schema override, validated at construction.
+    Declared(Vec<Column>),
+    /// Inferred from the first successfully encoded event, then frozen for
+    /// the lifetime of the `Record`. The store's `CREATE TABLE IF NOT EXISTS`
+    /// freezes the table on the first write anyway, so later events that
+    /// would infer differently (e.g. a `u64` crossing `i64::MAX`) only vary
+    /// in value affinity, which SQLite absorbs.
+    Inferred(OnceLock<Vec<Column>>),
+}
+
+impl<E: SolEvent> Record<E> {
+    /// A `Record` for `E`, honouring an optional schema override.
+    ///
+    /// With an override, its table name and columns are used: each column's
+    /// value is looked up by name from the event's fields when encoding (a
+    /// missing field becomes `NULL`), so columns may be renamed-away,
+    /// reordered, or retyped without disturbing value alignment. Errs when
+    /// the override names a reserved identifier (the implicit columns or the
+    /// store's progress table).
+    ///
+    /// Without an override, the table name is derived from `E`'s Solidity
+    /// signature and the columns are frozen from the first encoded event.
+    pub fn new(override_: Option<TableSchema>) -> Result<Self> {
+        let (table, columns) = match override_ {
+            Some(schema) => {
+                // An override colliding with an implicit column would produce
+                // a `CREATE TABLE` with duplicate columns; surfacing it here
+                // makes the failure a clear construction error rather than an
+                // opaque SQL one.
+                if let Err(reason) = schema.ensure_no_reserved_names() {
+                    anyhow::bail!("invalid schema override: {reason}");
+                }
+                (schema.table, ColumnsSource::Declared(schema.columns))
+            }
+            None => (table_name::<E>(), ColumnsSource::Inferred(OnceLock::new())),
+        };
+        Ok(Self {
+            table,
+            columns,
+            _event: PhantomData,
+        })
+    }
+}
+
+impl<E> Record<E> {
+    /// The table this event type's rows are written to and replayed from.
+    pub fn table(&self) -> &str {
+        &self.table
+    }
+
+    /// The write schema: the event-field columns plus the implicit
+    /// [`PAYLOAD_COLUMN`]. Available immediately for a declared schema;
+    /// `None` for an inferred one until the first successful [`encode`]
+    /// freezes it.
+    ///
+    /// [`encode`]: Record::encode
+    pub fn schema(&self) -> Option<TableSchema> {
+        let columns = match &self.columns {
+            ColumnsSource::Declared(columns) => columns.as_slice(),
+            ColumnsSource::Inferred(lock) => lock.get()?.as_slice(),
+        };
+        let mut columns = columns.to_vec();
+        columns.push(Column::new(PAYLOAD_COLUMN, SqlType::Text));
+        Some(TableSchema {
+            table: self.table.clone(),
+            columns,
+        })
+    }
+
+    /// The schema used to read back stored events for replay: the table name
+    /// plus the single [`PAYLOAD_COLUMN`]. Needs no encoded event, so replay
+    /// can run before any live event is seen.
+    pub fn payload_schema(&self) -> TableSchema {
+        TableSchema::new(self.table.clone()).col(PAYLOAD_COLUMN, SqlType::Text)
+    }
+
+    /// Encode one event as a [`Row`] aligned to the frozen columns (a column
+    /// with no matching field becomes `NULL`), with the event's full JSON
+    /// appended as the [`PAYLOAD_COLUMN`] for lossless replay.
+    pub fn encode(&self, event: &E) -> Result<Row>
+    where
+        E: Serialize,
+    {
+        // One serialisation pass feeds both the field map and the payload
+        // column; this runs once per event on the persistence hot path.
+        let json = event_json(event)?;
+        let fields = field_map(&json)?;
+        let columns = self.freeze_columns(&fields)?;
+        let mut values: Vec<SqlValue> = columns
+            .iter()
+            .map(|col| {
+                fields
+                    .get(&col.name)
+                    .map(|(_, value)| value.clone())
+                    .unwrap_or(SqlValue::Null)
+            })
+            .collect();
+        values.push(SqlValue::Text(json.to_string()));
+        Ok(Row(values))
+    }
+
+    /// Reconstruct an event from a stored [`PAYLOAD_COLUMN`] value.
+    pub fn decode(&self, payload: &str) -> Result<E>
+    where
+        E: DeserializeOwned,
+    {
+        serde_json::from_str(payload).context("stored payload is not valid for this event type")
+    }
+
+    /// The frozen event-field columns, inferring them from `fields` on the
+    /// first call when no schema was declared.
+    fn freeze_columns(&self, fields: &BTreeMap<String, (SqlType, SqlValue)>) -> Result<&[Column]> {
+        match &self.columns {
+            ColumnsSource::Declared(columns) => Ok(columns),
+            ColumnsSource::Inferred(lock) => {
+                if let Some(columns) = lock.get() {
+                    return Ok(columns);
+                }
+                for name in fields.keys() {
+                    // The store adds BLOCK_NUMBER_COLUMN and `encode` appends
+                    // PAYLOAD_COLUMN; an event field by either name would
+                    // shadow them in `CREATE TABLE` and break every write.
+                    if name == BLOCK_NUMBER_COLUMN || name == PAYLOAD_COLUMN {
+                        anyhow::bail!(
+                            "event field {name:?} is reserved for an implicit column \
+                             the persistence layer adds to every table; rename it \
+                             with a schema override"
+                        );
+                    }
+                }
+                let columns = fields
+                    .iter()
+                    .map(|(name, (ty, _))| Column::new(name.clone(), *ty))
+                    .collect();
+                // A concurrent encode may have frozen first; either winner
+                // derived from the same event type, so the loser's set is a
+                // no-op and `get` is now always populated.
+                let _ = lock.set(columns);
+                Ok(lock.get().expect("frozen above").as_slice())
+            }
+        }
+    }
+}
+
 /// The best-guess table name for an event type, derived from its Solidity
 /// signature: `ValueSet(uint256)` -> `value_set`.
-pub fn table_name<E: SolEvent>() -> String {
+fn table_name<E: SolEvent>() -> String {
     let signature = E::SIGNATURE;
     let name = signature.split('(').next().unwrap_or(signature);
     to_snake_case(name)
@@ -41,121 +204,6 @@ fn field_map(value: &Value) -> Result<BTreeMap<String, (SqlType, SqlValue)>> {
         .iter()
         .map(|(key, field)| (key.clone(), (infer_type(field), json_to_sql(field))))
         .collect())
-}
-
-/// The best-guess [`TableSchema`] and [`Row`] for a serialisable event:
-/// one column per top-level field, named and typed from the serialised JSON.
-pub fn derive<E>(event: &E) -> Result<(TableSchema, Row)>
-where
-    E: Serialize + SolEvent,
-{
-    let fields = field_map(&event_json(event)?)?;
-    let mut columns = Vec::with_capacity(fields.len());
-    let mut values = Vec::with_capacity(fields.len());
-    for (name, (ty, value)) in fields {
-        columns.push(Column::new(name, ty));
-        values.push(value);
-    }
-
-    Ok((
-        TableSchema {
-            table: table_name::<E>(),
-            columns,
-        },
-        Row(values),
-    ))
-}
-
-/// The schema and row for `event`, augmented with a [`PAYLOAD_COLUMN`] holding
-/// the event's full JSON. The per-field columns make the table queryable; the
-/// payload column makes replay lossless.
-pub fn derive_record<E>(event: &E) -> Result<(TableSchema, Row)>
-where
-    E: Serialize + SolEvent,
-{
-    derive_record_with(event, None)
-}
-
-/// Like [`derive_record`], but honouring an optional schema `override_`.
-///
-/// When an override is given, its table name and columns are used: each
-/// override column's value is looked up by name from the event's fields (a
-/// missing field becomes `NULL`), so columns may be renamed-away, reordered, or
-/// retyped without disturbing value alignment. The [`PAYLOAD_COLUMN`] is always
-/// appended for lossless replay.
-pub fn derive_record_with<E>(
-    event: &E,
-    override_: Option<&TableSchema>,
-) -> Result<(TableSchema, Row)>
-where
-    E: Serialize + SolEvent,
-{
-    // One serialisation pass feeds both the field map and the payload column;
-    // this runs once per event on the persistence hot path.
-    let json = event_json(event)?;
-    let fields = field_map(&json)?;
-
-    let (table, columns, mut values) = match override_ {
-        Some(schema) => {
-            // An override colliding with an implicit column would produce a
-            // `CREATE TABLE` with duplicate columns; surfacing it here makes
-            // the failure a clear derive error rather than an opaque SQL one.
-            if let Err(reason) = schema.ensure_no_reserved_names() {
-                anyhow::bail!("invalid schema override: {reason}");
-            }
-            let values = schema
-                .columns
-                .iter()
-                .map(|col| {
-                    fields
-                        .get(&col.name)
-                        .map(|(_, value)| value.clone())
-                        .unwrap_or(SqlValue::Null)
-                })
-                .collect();
-            (schema.table.clone(), schema.columns.clone(), values)
-        }
-        None => {
-            let mut columns = Vec::with_capacity(fields.len());
-            let mut values = Vec::with_capacity(fields.len());
-            for (name, (ty, value)) in &fields {
-                // The store adds BLOCK_NUMBER_COLUMN and this fn appends
-                // PAYLOAD_COLUMN; an event field by either name would shadow
-                // them in `CREATE TABLE` and break every write.
-                if name == BLOCK_NUMBER_COLUMN || name == PAYLOAD_COLUMN {
-                    anyhow::bail!(
-                        "event field {name:?} is reserved for an implicit column \
-                         the persistence layer adds to every table; rename it \
-                         with a schema override"
-                    );
-                }
-                columns.push(Column::new(name.clone(), *ty));
-                values.push(value.clone());
-            }
-            (table_name::<E>(), columns, values)
-        }
-    };
-
-    let mut schema = TableSchema { table, columns };
-    let payload = json.to_string();
-    schema
-        .columns
-        .push(Column::new(PAYLOAD_COLUMN, SqlType::Text));
-    values.push(SqlValue::Text(payload));
-
-    Ok((schema, Row(values)))
-}
-
-/// The schema used to read back stored events for replay: the table name plus
-/// the single [`PAYLOAD_COLUMN`]. Needs no event instance, so replay can run
-/// before any live event is seen.
-pub fn payload_schema<E: SolEvent>() -> TableSchema {
-    TableSchema::new(table_name::<E>()).col(PAYLOAD_COLUMN, SqlType::Text)
-}
-
-/// Reconstruct an event from a stored [`PAYLOAD_COLUMN`] value.
-pub fn from_payload<E: DeserializeOwned>(payload: &str) -> Result<E> {
-    serde_json::from_str(payload).context("stored payload is not valid for this event type")
 }
 
 /// Best-guess SQL type for a serialised field value.

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -11,9 +11,8 @@ use alloy::sol;
 use anyhow::Result;
 use artemis_light::collectors::EventCollector;
 use artemis_light::persistence::{
-    Column, PersistExt, PersistableCollector, Row, SqlType, SqlValue, SqliteStore, Store,
-    TableSchema, derive, derive_record, derive_record_with, from_payload, payload_schema,
-    table_name,
+    Column, PersistExt, PersistableCollector, Record, Row, SqlType, SqlValue, SqliteStore, Store,
+    TableSchema,
 };
 use artemis_light::types::{Collector, CollectorStream};
 use async_trait::async_trait;
@@ -305,61 +304,56 @@ async fn write_block_is_atomic_on_failure() {
     assert_eq!(store.last_block(&schema.table).await.unwrap(), Some(5));
 }
 
-/// Slice 4: schema is derived from a Serialize+SolEvent type — table name from
-/// the Solidity signature, columns from the event's field names.
-#[tokio::test]
-async fn derive_schema_uses_event_name_and_field_names() {
-    let event = ValueSet {
-        value: U256::from(42),
-    };
-
-    assert_eq!(table_name::<ValueSet>(), "value_set");
-
-    let (schema, _row) = derive(&event).unwrap();
-    assert_eq!(schema.table, "value_set");
-    assert_eq!(schema.columns, vec![Column::new("value", SqlType::Text)]);
-}
-
-/// A multi-field event derives one column per field, named after the field and
-/// ordered deterministically (by field name), with values aligned to columns.
+/// Slice 4: a Record without a declared schema is a best guess from the event
+/// type — table name from the Solidity signature, columns frozen from the
+/// first encoded event (named after its fields, ordered deterministically by
+/// field name), no schema reported before that.
 #[test]
-fn derive_maps_each_event_field_to_a_column() {
-    let (schema, Row(values)) = derive(&transfer_event()).unwrap();
+fn record_freezes_inferred_schema_from_first_encoded_event() {
+    let record = Record::<Transfer>::new(None).unwrap();
+    assert_eq!(record.table(), "transfer");
+    assert!(
+        record.schema().is_none(),
+        "no schema before the first encode freezes one"
+    );
 
+    let Row(values) = record.encode(&transfer_event()).unwrap();
+
+    let schema = record.schema().unwrap();
     assert_eq!(schema.table, "transfer");
     let names: Vec<&str> = schema.columns.iter().map(|c| c.name.as_str()).collect();
-    // Sorted by field name: `amount` before `from`.
-    assert_eq!(names, vec!["amount", "from"]);
-    assert_eq!(values.len(), 2);
+    // Sorted by field name (`amount` before `from`), with `_payload` appended.
+    assert_eq!(names, vec!["amount", "from", "_payload"]);
+    assert_eq!(values.len(), 3);
 }
 
-/// `derive_record` appends an implicit `_payload` column holding the event's
-/// full JSON, and that payload round-trips back to an equal event.
+/// The implicit `_payload` column holds the event's full JSON, and that
+/// payload round-trips back to an equal event through `decode`.
 #[test]
-fn derive_record_appends_payload_column_that_round_trips() {
+fn record_payload_column_round_trips_through_decode() {
     let event = transfer_event();
-    let (schema, Row(values)) = derive_record(&event).unwrap();
-
-    let names: Vec<&str> = schema.columns.iter().map(|c| c.name.as_str()).collect();
-    assert_eq!(names, vec!["amount", "from", "_payload"]);
+    let record = Record::<Transfer>::new(None).unwrap();
+    let Row(values) = record.encode(&event).unwrap();
 
     let SqlValue::Text(payload) = values.last().unwrap() else {
         panic!("payload column should be text");
     };
-    let restored: Transfer = from_payload(payload).unwrap();
-    assert_eq!(restored, event);
+    assert_eq!(record.decode(payload).unwrap(), event);
 }
 
 /// A schema override redirects the table, renames-away unlisted fields, fills
 /// columns with no matching field with `NULL`, and still appends `_payload`.
 #[test]
-fn derive_record_with_override_aligns_values_by_column_name() {
+fn record_with_override_aligns_values_by_column_name() {
     let event = transfer_event();
     let override_ = TableSchema::new("transfers_custom")
         .col("amount", SqlType::Numeric) // kept and retyped
         .col("missing", SqlType::Text); // no matching event field
 
-    let (schema, Row(values)) = derive_record_with(&event, Some(&override_)).unwrap();
+    let record = Record::<Transfer>::new(Some(override_)).unwrap();
+    // A declared schema is available before anything is encoded.
+    let schema = record.schema().unwrap();
+    let Row(values) = record.encode(&event).unwrap();
 
     // Table and column set follow the override, with `_payload` appended; the
     // `from` field is renamed-away because the override does not list it.
@@ -375,7 +369,7 @@ fn derive_record_with_override_aligns_values_by_column_name() {
     let SqlValue::Text(payload) = values.last().unwrap() else {
         panic!("payload column should be text");
     };
-    assert_eq!(from_payload::<Transfer>(payload).unwrap(), event);
+    assert_eq!(record.decode(payload).unwrap(), event);
 }
 
 /// A store that accepts nothing and returns nothing — for tests that must
@@ -424,15 +418,16 @@ sol! {
 }
 
 /// An event field named after an implicit column cannot be stored — the
-/// derived `CREATE TABLE` would have duplicate columns and persistence would
-/// halt on the first write with an opaque SQL error. Deriving must fail with
+/// inferred `CREATE TABLE` would have duplicate columns and persistence would
+/// halt on the first write with an opaque SQL error. Encoding must fail with
 /// a clear message instead (which halts persistence loudly at the source).
 #[test]
-fn derive_rejects_event_fields_shadowing_implicit_columns() {
+fn record_rejects_event_fields_shadowing_implicit_columns() {
     let event = Sneaky {
         block_number: U256::from(1),
     };
-    let err = derive_record(&event).unwrap_err().to_string();
+    let record = Record::<Sneaky>::new(None).unwrap();
+    let err = record.encode(&event).unwrap_err().to_string();
     assert!(
         err.contains("reserved"),
         "error should name the reserved column, got: {err}"
@@ -440,19 +435,25 @@ fn derive_rejects_event_fields_shadowing_implicit_columns() {
 }
 
 /// `payload_schema` describes the read-back shape — table name plus the single
-/// `_payload` column — without needing an event instance.
+/// `_payload` column — without needing an encoded event, and it follows the
+/// declared table when a schema override redirects it.
 #[test]
 fn payload_schema_is_table_plus_payload_column() {
-    let schema = payload_schema::<Transfer>();
+    let record = Record::<Transfer>::new(None).unwrap();
+    let schema = record.payload_schema();
     assert_eq!(schema.table, "transfer");
     assert_eq!(schema.columns, vec![Column::new("_payload", SqlType::Text)]);
+
+    let redirected = Record::<Transfer>::new(Some(TableSchema::new("transfers_custom"))).unwrap();
+    assert_eq!(redirected.payload_schema().table, "transfers_custom");
 }
 
 /// A stored payload that is not valid JSON for the event type is a hard error,
 /// never a silently dropped row.
 #[test]
-fn from_payload_errors_on_unreadable_text() {
-    assert!(from_payload::<Transfer>("not a valid payload").is_err());
+fn decode_errors_on_unreadable_text() {
+    let record = Record::<Transfer>::new(None).unwrap();
+    assert!(record.decode("not a valid payload").is_err());
 }
 
 /// Slice 7: a `Persisted` collector records live events one transaction per
@@ -482,7 +483,9 @@ async fn persisted_records_live_events_per_complete_block() {
 
 /// Persist one event at `block` as if a previous run had stored it.
 async fn seed(store: &SqliteStore, block: u64, value: u64) {
-    let (schema, row) = derive_record(&value_event(value)).unwrap();
+    let record = Record::<ValueSet>::new(None).unwrap();
+    let row = record.encode(&value_event(value)).unwrap();
+    let schema = record.schema().unwrap();
     store.write_block(&schema, block, vec![row]).await.unwrap();
 }
 


### PR DESCRIPTION
Consolidate derive_record/derive_record_with/from_payload into a Record type that owns the table name, the column schema (declared or frozen from the first encoded event), both encode/decode directions, and the reserved-name invariant. Persisted constructs one Record per subscription and shares it between the backfill and live writers.

Also fold Map into FilterMap's stream adaptation via a shared subscribe_filter_mapped helper, and document the Record term in CONTEXT.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the persistence hot path (encode/replay/backfill/live) but is largely a structural refactor with existing integration tests; schema-freeze timing is now centralized on one shared `Record` per subscription.
> 
> **Overview**
> Introduces **`Record<E>`** as the single owner of event↔SQL mapping, replacing the free functions `derive`, `derive_record`, `derive_record_with`, `from_payload`, and `payload_schema`. A `Record` holds the table name, declared or first-encode-frozen columns (`OnceLock` for inferred schemas), **`encode`** / **`decode`**, and reserved-name checks; the public persistence surface now exports only **`Record`**.
> 
> **`Persisted`** builds one **`Arc<Record<E>>`** per subscribe and threads it through replay (`payload_schema` + `decode`), backfill, and live **`BlockWriter`** paths so backfill and live share the same frozen schema. **`BlockWriter`** no longer tracks a per-writer schema; it calls **`record.encode`** and reads **`record.schema()`** after the first successful encode.
> 
> Collector **`Map`** now delegates to shared **`subscribe_filter_mapped`** in **`filter_map`** (map = filter-map that always returns `Some`). **`CONTEXT.md`** documents the **Record** term and its relationship to **Persisted Collector**. Tests and module docs are updated to the `Record` API; behavior (gap-free writes, replay-once, halt-on-failure) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db32094821d7360307d03f777737bbe3645f23b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->